### PR TITLE
Several enhancements to the triplestore library

### DIFF
--- a/triplestore/pyproject.toml
+++ b/triplestore/pyproject.toml
@@ -39,6 +39,8 @@ qlever = ["requests>=2.32.4"]
 
 rdf4j = ["requests>=2.32.4"]
 
+virtuoso = ["requests>=2.32.4"]
+
 all = [
     "agraph-python>=104.3.0",
     "psutil>=7.0.0",
@@ -61,6 +63,7 @@ jena         = "triplestore.backends.jena:Jena"
 oxigraph     = "triplestore.backends.oxigraph:Oxigraph"
 qlever       = "triplestore.backends.qlever:QLever"
 rdf4j        = "triplestore.backends.rdf4j:RDF4J"
+virtuoso     = "triplestore.backends.virtuoso:Virtuoso"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/triplestore/pyproject.toml
+++ b/triplestore/pyproject.toml
@@ -37,6 +37,8 @@ oxigraph = ["pyoxigraph>=0.4.11"]
 
 qlever = ["requests>=2.32.4"]
 
+rdf4j = ["requests>=2.32.4"]
+
 all = [
     "agraph-python>=104.3.0",
     "psutil>=7.0.0",
@@ -57,7 +59,8 @@ blazegraph   = "triplestore.backends.blazegraph:Blazegraph"
 graphdb      = "triplestore.backends.graphdb:GraphDB"
 jena         = "triplestore.backends.jena:Jena"
 oxigraph     = "triplestore.backends.oxigraph:Oxigraph"
-qlever     = "triplestore.backends.qlever:QLever"
+qlever       = "triplestore.backends.qlever:QLever"
+rdf4j        = "triplestore.backends.rdf4j:RDF4J"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/triplestore/pyproject.toml
+++ b/triplestore/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 requires-python = ">=3.10"
 
 dependencies = [
-
+    "shapely>=2.1.2",
 ]
 
 [build-system]
@@ -46,6 +46,7 @@ all = [
     "psutil>=7.0.0",
     "pyoxigraph>=0.4.11",
     "requests>=2.32.4",
+    "shapely>=2.1.2",
 ]
 
 dev = [

--- a/triplestore/pyproject.toml
+++ b/triplestore/pyproject.toml
@@ -35,6 +35,8 @@ jena =[
 
 oxigraph = ["pyoxigraph>=0.4.11"]
 
+qlever = ["requests>=2.32.4"]
+
 all = [
     "agraph-python>=104.3.0",
     "psutil>=7.0.0",
@@ -55,6 +57,7 @@ blazegraph   = "triplestore.backends.blazegraph:Blazegraph"
 graphdb      = "triplestore.backends.graphdb:GraphDB"
 jena         = "triplestore.backends.jena:Jena"
 oxigraph     = "triplestore.backends.oxigraph:Oxigraph"
+qlever     = "triplestore.backends.qlever:QLever"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/triplestore/src/triplestore/backends/allegrograph.py
+++ b/triplestore/src/triplestore/backends/allegrograph.py
@@ -18,6 +18,7 @@ from triplestore.utils import (
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
+    validate_rdf_term,
 )
 
 logger = logging.getLogger(__name__)
@@ -147,19 +148,23 @@ class AllegroGraph(TriplestoreBackend):
             msg = f"[AllegroGraph] GSP load failed with status {response.status_code}:\n{response.text}"
             raise RuntimeError(msg)
 
-    def add(self, s: str, p: str, o: str) -> None:
+    def add(self, s: Any, p: Any, o: Any) -> None:
         """
         Add a triple to the AllegroGraph store.
 
         Parameters:
-        s : str
-            The subject URI of the triple.
-        p : str
-            The predicate URI of the triple.
-        o : str
-            The object URI of the triple.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "AllegroGraph")
+        p_term = validate_rdf_term(p, "predicate", "AllegroGraph")
+        o_term = validate_rdf_term(o, "object", "AllegroGraph")
+
+        triple = f"{s_term} {p_term} {o_term} ."
 
         if self.graph_uri:
             sparql = f"""
@@ -182,19 +187,39 @@ class AllegroGraph(TriplestoreBackend):
 
         self._run_update(sparql)
 
-    def delete(self, s: str, p: str, o: str) -> None:
+    def delete(self, s: Any, p: Any, o: Any) -> None:
         """
         Delete a triple from the AllegroGraph store.
 
         Parameters:
-        s : str
-            The subject URI of the triple to remove.
-        p : str
-            The predicate URI of the triple to remove.
-        o : str
-            The object URI of the triple to remove.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
+
+        Raises
+        ------
+        ValueError
+            If a blank node is provided as the subject.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "AllegroGraph")
+        p_term = validate_rdf_term(p, "predicate", "AllegroGraph")
+        o_term = validate_rdf_term(o, "object", "AllegroGraph")
+
+        if isinstance(s, str) and s.startswith("_:"):
+            msg = (
+                "[AllegroGraph] Cannot delete triples using a blank node as subject.\n\n"
+                "Blank node identifiers (e.g. '_:b1') are local to a single SPARQL query "
+                "or update and do not represent stable, reusable identifiers.\n"
+                "Recommended alternatives:\n"
+                " - Use a persistent IRI instead of a blank node if you need to delete the triple later.\n"
+                " - Or delete using a pattern-based query (e.g. DELETE WHERE) that matches the triple.\n\n"
+            )
+            raise ValueError(msg)
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri else

--- a/triplestore/src/triplestore/backends/allegrograph.py
+++ b/triplestore/src/triplestore/backends/allegrograph.py
@@ -15,6 +15,7 @@ from triplestore.utils import (
     export_ask_result,
     export_rdf_result,
     export_select_results,
+    get_rdf_content_type,
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
@@ -120,10 +121,14 @@ class AllegroGraph(TriplestoreBackend):
         """
         Load RDF data into the repository using the Graph Store Protocol.
 
+        Supported formats:
+        - .ttl: Turtle
+        - .nt: N-Triples
+
         Parameters
         ----------
         filename : str
-            Path to the RDF file to load (e.g. Turtle).
+            Path to the RDF file to load (.ttl or .nt).
 
         Raises
         ------
@@ -137,12 +142,15 @@ class AllegroGraph(TriplestoreBackend):
             msg = f"[AllegroGraph] File not found: {filename}"
             raise FileNotFoundError(msg)
 
+        content_type = get_rdf_content_type(filename, backend_name="AllegroGraph")
+        headers = {"Content-Type": content_type}
+
         params: dict[str, str] = {}
         if self.graph_uri:
             params["context"] = f"<{self.graph_uri}>"
 
         with path.open("rb") as f:
-            response = requests.post(self.load_url, params=params, data=f, headers=self.headers_load, auth=self.auth, timeout=None)
+            response = requests.post(self.load_url, params=params, data=f, headers=headers, auth=self.auth, timeout=None)
 
         if response.status_code not in {200, 201, 204}:
             msg = f"[AllegroGraph] GSP load failed with status {response.status_code}:\n{response.text}"

--- a/triplestore/src/triplestore/backends/allegrograph.py
+++ b/triplestore/src/triplestore/backends/allegrograph.py
@@ -11,7 +11,14 @@ import requests
 from franz.openrdf.connect import ag_connect
 
 from triplestore.base import TriplestoreBackend
-from triplestore.utils import validate_config
+from triplestore.utils import (
+    export_ask_result,
+    export_rdf_result,
+    export_select_results,
+    get_sparql_query_type,
+    resolve_export_format,
+    validate_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -152,14 +159,6 @@ class AllegroGraph(TriplestoreBackend):
         o : str
             The object URI of the triple.
         """
-        # triple = f"<{s}> <{p}> <{o}> ."
-        # sparql = (
-        #     f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
-        #     if self.graph_uri else
-        #     f"INSERT DATA {{ {triple} }}"
-        # )
-        # self._run_update(sparql)
-
         triple = f"<{s}> <{p}> <{o}> ."
 
         if self.graph_uri:
@@ -183,7 +182,6 @@ class AllegroGraph(TriplestoreBackend):
 
         self._run_update(sparql)
 
-
     def delete(self, s: str, p: str, o: str) -> None:
         """
         Delete a triple from the AllegroGraph store.
@@ -204,23 +202,49 @@ class AllegroGraph(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def query(self, sparql: str) -> list[dict[str, str]]:
+    def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
         """
         Run a SPARQL SELECT query against the AllegroGraph repository.
 
-        Parameters:
+        Parameters
+        ----------
         sparql : str
             The SPARQL query string.
+        export : bool, optional
+            If True, also save the query results to a local file.
+        output_format : str, optional
+            Export format for saved results. Supported: 'json', 'csv'.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically
+            from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
-        Returns:
-        list of dict
+        Returns
+        -------
+        list[dict[str, str]]
             The list of query result bindings.
 
         Raises
         ------
+        ValueError
+            If query() is called with a non-SELECT query or with an unsupported export format.
         RuntimeError
             If the query fails or the server returns an error response.
         """
+        query_type = get_sparql_query_type(sparql)
+
+        if query_type != "SELECT":
+            msg = (
+                f"[AllegroGraph] Unsupported query type '{query_type}' for query(). "
+                "Only SELECT queries are supported. "
+                "Use execute() for UPDATE queries or other query forms."
+            )
+            raise ValueError(msg)
+
+        if export:
+            chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="AllegroGraph")
+
         response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
 
         if response.status_code != 200:
@@ -229,9 +253,14 @@ class AllegroGraph(TriplestoreBackend):
 
         data = response.json()
         bindings = data.get("results", {}).get("bindings", [])
-        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+        results = [{k: v["value"] for k, v in row.items()} for row in bindings]
 
-    def execute(self, sparql: str) -> Any:
+        if export:
+            export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="AllegroGraph")
+
+        return results
+
+    def execute(self, sparql: str, *, export: bool = False, output_format: str | None = None, filename: str | None = None, separator: str = ",") -> Any:
         """
         Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
 
@@ -239,6 +268,16 @@ class AllegroGraph(TriplestoreBackend):
         ----------
         sparql : str
             The SPARQL query or update string.
+        export : bool, optional
+            If True, also save the query result to a local file.
+        output_format : str, optional
+            Export format for saved results. If omitted and export=True, a default format is chosen
+            based on the query type.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically
+            from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
         Returns
         -------
@@ -253,21 +292,8 @@ class AllegroGraph(TriplestoreBackend):
         RuntimeError
             If the server responds with an error status.
         """
-        qstrip = sparql.lstrip()
-        query_type = qstrip.split(None, 1)[0].upper() if qstrip else ""
-        if not query_type:
-            msg = "[AllegroGraph] Could not detect SPARQL keyword."
-            raise RuntimeError(msg)
-
-        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
-
-        query_type = ""
-        for line in lines:
-            upper = line.upper()
-            if upper.startswith("PREFIX ") or upper.startswith("BASE "):
-                continue
-            query_type = line.split(None, 1)[0].upper()
-            break
+        query_type = get_sparql_query_type(sparql)
+        chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="AllegroGraph")
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:
@@ -278,10 +304,19 @@ class AllegroGraph(TriplestoreBackend):
                 raise RuntimeError(msg)
 
             data = response.json()
+
             if query_type == "ASK":
-                return bool(data.get("boolean", False))
+                result = bool(data.get("boolean", False))
+                if export:
+                    export_ask_result(result, output_format=chosen_format, filename=filename, backend_name="AllegroGraph")
+                return result
+
             bindings = data.get("results", {}).get("bindings", [])
-            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+            results = [{k: v["value"] for k, v in row.items()} for row in bindings]
+            if export:
+                export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="AllegroGraph")
+
+            return results
 
         # CONSTRUCT / DESCRIBE
         if query_type in {"CONSTRUCT", "DESCRIBE"}:
@@ -290,11 +325,19 @@ class AllegroGraph(TriplestoreBackend):
             if response.status_code != 200:
                 msg = f"[AllegroGraph] Graph query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
-            return response.text
+
+            rdf_text = response.text
+
+            if export:
+                export_rdf_result(rdf_text, output_format=chosen_format, filename=filename, backend_name="AllegroGraph")
+
+            return rdf_text
 
         # UPDATE
-        if query_type in {"WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
-                "MOVE", "COPY", "ADD", "MODIFY"}:
+        if query_type in {
+            "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
+            "MOVE", "COPY", "ADD", "MODIFY"
+        }:
             self._run_update(sparql)
             return None
 

--- a/triplestore/src/triplestore/backends/allegrograph.py
+++ b/triplestore/src/triplestore/backends/allegrograph.py
@@ -152,13 +152,37 @@ class AllegroGraph(TriplestoreBackend):
         o : str
             The object URI of the triple.
         """
+        # triple = f"<{s}> <{p}> <{o}> ."
+        # sparql = (
+        #     f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
+        #     if self.graph_uri else
+        #     f"INSERT DATA {{ {triple} }}"
+        # )
+        # self._run_update(sparql)
+
         triple = f"<{s}> <{p}> <{o}> ."
-        sparql = (
-            f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
-            if self.graph_uri else
-            f"INSERT DATA {{ {triple} }}"
-        )
+
+        if self.graph_uri:
+            sparql = f"""
+            INSERT {{
+            GRAPH <{self.graph_uri}> {{ {triple} }}
+            }}
+            WHERE {{
+            FILTER NOT EXISTS {{
+                GRAPH <{self.graph_uri}> {{ {triple} }}
+            }}
+            }}
+            """
+        else:
+            sparql = f"""
+            INSERT {{ {triple} }}
+            WHERE {{
+            FILTER NOT EXISTS {{ {triple} }}
+            }}
+            """
+
         self._run_update(sparql)
+
 
     def delete(self, s: str, p: str, o: str) -> None:
         """
@@ -234,6 +258,16 @@ class AllegroGraph(TriplestoreBackend):
         if not query_type:
             msg = "[AllegroGraph] Could not detect SPARQL keyword."
             raise RuntimeError(msg)
+
+        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
+
+        query_type = ""
+        for line in lines:
+            upper = line.upper()
+            if upper.startswith("PREFIX ") or upper.startswith("BASE "):
+                continue
+            query_type = line.split(None, 1)[0].upper()
+            break
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:

--- a/triplestore/src/triplestore/backends/blazegraph.py
+++ b/triplestore/src/triplestore/backends/blazegraph.py
@@ -15,6 +15,7 @@ from triplestore.utils import (
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
+    validate_rdf_term,
 )
 
 logger = logging.getLogger(__name__)
@@ -90,19 +91,23 @@ class Blazegraph(TriplestoreBackend):
             msg = f"[Blazegraph] Load failed: {response.status_code}\n{response.text}"
             raise RuntimeError(msg)
 
-    def add(self, s: str, p: str, o: str) -> None:
+    def add(self, s: Any, p: Any, o: Any) -> None:
         """
         Add a triple to the Blazegraph store.
 
         Parameters:
-        s : str
-            Subject URI.
-        p : str
-            Predicate URI.
-        o : str
-            Object URI.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "Blazegraph")
+        p_term = validate_rdf_term(p, "predicate", "Blazegraph")
+        o_term = validate_rdf_term(o, "object", "Blazegraph")
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri else
@@ -110,19 +115,39 @@ class Blazegraph(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def delete(self, s: str, p: str, o: str) -> None:
+    def delete(self, s: Any, p: Any, o: Any) -> None:
         """
         Delete a triple from the Blazegraph store.
 
         Parameters:
-        s : str
-            Subject URI.
-        p : str
-            Predicate URI.
-        o : str
-            Object URI.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
+
+        Raises
+        ------
+        ValueError
+            If a blank node is provided as the subject.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "Blazegraph")
+        p_term = validate_rdf_term(p, "predicate", "Blazegraph")
+        o_term = validate_rdf_term(o, "object", "Blazegraph")
+
+        if isinstance(s, str) and s.startswith("_:"):
+            msg = (
+                "[Blazegraph] Cannot delete triples using a blank node as subject.\n\n"
+                "Blank node identifiers (e.g. '_:b1') are local to a single SPARQL query "
+                "or update and do not represent stable, reusable identifiers.\n"
+                "Recommended alternatives:\n"
+                " - Use a persistent IRI instead of a blank node if you need to delete the triple later.\n"
+                " - Or delete using a pattern-based query (e.g. DELETE WHERE) that matches the triple.\n\n"
+            )
+            raise ValueError(msg)
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri else

--- a/triplestore/src/triplestore/backends/blazegraph.py
+++ b/triplestore/src/triplestore/backends/blazegraph.py
@@ -8,7 +8,14 @@ from typing import Any
 import requests
 
 from triplestore.base import TriplestoreBackend
-from triplestore.utils import validate_config
+from triplestore.utils import (
+    export_ask_result,
+    export_rdf_result,
+    export_select_results,
+    get_sparql_query_type,
+    resolve_export_format,
+    validate_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -123,15 +130,25 @@ class Blazegraph(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def execute(self, sparql: str) -> Any:
+    def execute(self, sparql: str, *, export: bool = False, output_format: str | None = None, filename: str | None = None, separator: str = ",") -> Any:
         """
         Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
 
-        Parameters:
+        Parameters
+        ----------
         sparql : str
             The SPARQL query or update string.
+        export : bool, optional
+            If True, also save the query result to a local file.
+        output_format : str, optional
+            Export format for saved results. If omitted and export=True, a default format is chosen based on the query type.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
-        Returns:
+        Returns
+        -------
         Any
             - list of dict for SELECT
             - bool for ASK
@@ -143,7 +160,8 @@ class Blazegraph(TriplestoreBackend):
         RuntimeError
             If the server responds with an error.
         """
-        query_type = sparql.strip().split(maxsplit=1)[0].upper()
+        query_type = get_sparql_query_type(sparql)
+        chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="Blazegraph")
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:
@@ -153,45 +171,89 @@ class Blazegraph(TriplestoreBackend):
                 raise RuntimeError(msg)
 
             data = response.json()
-            if query_type == "ASK":
-                return bool(data.get("boolean", False))
-            bindings = data.get("results", {}).get("bindings", [])
-            return [{k: v["value"] for k, v in row.items()} for row in bindings]
 
-        # CONSTRUCT / DESCRIBE → RDF (Turtle)
+            if query_type == "ASK":
+                result = bool(data.get("boolean", False))
+                if export:
+                    export_ask_result(result, output_format=chosen_format, filename=filename, backend_name="Blazegraph")
+                return result
+
+            bindings = data.get("results", {}).get("bindings", [])
+            results = [{k: v["value"] for k, v in row.items()} for row in bindings]
+
+            if export:
+                export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="Blazegraph")
+
+            return results
+
+        # CONSTRUCT / DESCRIBE
         if query_type in {"CONSTRUCT", "DESCRIBE"}:
             response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": sparql}, timeout=None)
             if response.status_code != 200:
                 msg = f"[Blazegraph] SPARQL query failed: {response.status_code}\n{response.text}"
                 raise RuntimeError(msg)
-            return response.text
+
+            rdf_text = response.text
+
+            if export:
+                export_rdf_result(rdf_text, output_format=chosen_format, filename=filename, backend_name="Blazegraph")
+
+            return rdf_text
 
         # UPDATE family
-        if query_type in {"WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
-                "MOVE", "COPY", "ADD", "MODIFY"}:
+        if query_type in {
+            "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
+            "MOVE", "COPY", "ADD", "MODIFY"
+        }:
             self._run_update(sparql)
             return None
 
         msg = f"[Blazegraph] Unsupported SPARQL keyword: {query_type}"
         raise RuntimeError(msg)
 
-    def query(self, sparql: str) -> list[dict[str, str]]:
+    def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
         """
         Execute a SPARQL SELECT query against Blazegraph.
 
-        Parameters:
+        Parameters
+        ----------
         sparql : str
             The SPARQL query string.
+        export : bool, optional
+            If True, also save the query results to a local file.
+        output_format : str, optional
+            Export format for saved results. Supported: 'json', 'csv'.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically
+            from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
-        Returns:
-        list of dict
+        Returns
+        -------
+        list[dict[str, str]]
             A list of bindings from the query results.
 
         Raises
         ------
+        ValueError
+            If query() is called with a non-SELECT query or with an unsupported export format.
         RuntimeError
             If the query fails or the response is invalid.
         """
+        query_type = get_sparql_query_type(sparql)
+
+        if query_type != "SELECT":
+            msg = (
+                f"[Blazegraph] Unsupported query type '{query_type}' for query(). "
+                "Only SELECT queries are supported. "
+                "Use execute() for UPDATE queries or other query forms."
+            )
+            raise ValueError(msg)
+
+        if export:
+            chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="Blazegraph")
+
         response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, timeout=None)
         if response.status_code != 200:
             msg = f"[Blazegraph] SPARQL query failed: {response.status_code}\n{response.text}"
@@ -199,7 +261,12 @@ class Blazegraph(TriplestoreBackend):
 
         data = response.json()
         bindings = data.get("results", {}).get("bindings", [])
-        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+        results = [{k: v["value"] for k, v in row.items()} for row in bindings]
+
+        if export:
+            export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="Blazegraph")
+
+        return results
 
     def clear(self) -> None:
         """

--- a/triplestore/src/triplestore/backends/blazegraph.py
+++ b/triplestore/src/triplestore/backends/blazegraph.py
@@ -12,6 +12,7 @@ from triplestore.utils import (
     export_ask_result,
     export_rdf_result,
     export_select_results,
+    get_rdf_content_type,
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
@@ -67,11 +68,15 @@ class Blazegraph(TriplestoreBackend):
 
     def load(self, filename: str) -> None:
         """
-        Load RDF triples from a Turtle (.ttl) file into Blazegraph.
+        Load RDF triples from a supported RDF file into Blazegraph.
+
+        Supported formats:
+        - .ttl: Turtle
+        - .nt: N-Triples
 
         Parameters:
         filename : str
-            Path to the Turtle file.
+            Path to the RDF file to load (.ttl or .nt).
 
         Raises
         ------
@@ -83,10 +88,13 @@ class Blazegraph(TriplestoreBackend):
         if not Path(filename).exists():
             msg = f"[Blazegraph] File not found: {filename}"
             raise FileNotFoundError(msg)
+        
+        content_type = get_rdf_content_type(filename, backend_name="Blazegraph")
+        headers = {"Content-Type": content_type}
 
         data = Path(filename).read_bytes()
         params = {"context-uri": self.graph_uri} if self.graph_uri else {}
-        response = requests.post(self.update_url, headers=self.headers_load, data=data, params=params, timeout=None)
+        response = requests.post(self.update_url, headers=headers, data=data, params=params, timeout=None)
         if response.status_code not in {200, 204, 201}:
             msg = f"[Blazegraph] Load failed: {response.status_code}\n{response.text}"
             raise RuntimeError(msg)

--- a/triplestore/src/triplestore/backends/graphdb.py
+++ b/triplestore/src/triplestore/backends/graphdb.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -73,8 +76,6 @@ class GraphDB(TriplestoreBackend):
         self.headers_update = {"Content-Type": "application/sparql-update"}
         self.headers_load = {"Content-Type": "text/turtle"}
 
-        self._ensure_repository_exists()
-
     def load(self, filename: str) -> None:
         """
         Load RDF triples from a Turtle (.ttl) file into the GraphDB repository.
@@ -94,6 +95,8 @@ class GraphDB(TriplestoreBackend):
             msg = f"[GraphDB] File not found: {filename}"
             raise FileNotFoundError(msg)
 
+        self._ensure_repository_exists()
+
         rdf_data = Path(filename).read_bytes()
         params = {}
         if self.graph_uri:
@@ -104,51 +107,106 @@ class GraphDB(TriplestoreBackend):
             msg = f"[GraphDB] Load failed with status {response.status_code}:\n{response.text}"
             raise RuntimeError(msg)
 
-    def bulk_load(self, filenames: str | list[str], *, target_graph: str | None = None) -> None:
+    def bulk_load(self, filenames: str | list[str], mode: str = "load", repository_id: str | None = None) -> None:
         """
-        Bulk-load one or more RDF files that already exist on the GraphDB server.
+        Bulk-load RDF data into GraphDB using the offline ImportRDF tool.
 
         Parameters
         ----------
         filenames : str or list[str]
-            Server-side file path(s), relative to the GraphDB import directory.
-        target_graph : str, optional
-            Named graph URI for this import. If omitted, the graph configured for this backend
-            instance is used. If neither is set, GraphDB uses its default import behavior.
+            One or more local RDF files or directories to import.
+        mode : str, default="load"
+            Import mode. Must be either "load" or "preload".
+        repository_id : str, optional
+            Repository ID to import into. If omitted, the configured backend repository name is used.
 
         Raises
         ------
         ValueError
-            If no server-side file paths are provided.
+            If `mode` is invalid or no input files are provided.
+        FileNotFoundError
+            If one of the input paths does not exist, or if the ImportRDF executable cannot be found.
         RuntimeError
-            If the bulk-load request fails or the server returns a non-success status.
+            If the GraphDB server appears to be running or if the import fails.
         """
-        file_names = [filenames] if isinstance(filenames, str) else [name for name in filenames if name]
-
-        if not file_names:
+        if mode not in {"load", "preload"}:
             msg = (
-                "[GraphDB] bulk_load() requires at least one non-empty server-side file path. "
-                "Ensure that the file exists in the GraphDB import directory."
+                f"[GraphDB] bulk_load() received an invalid mode: '{mode}'. "
+                "Supported modes are 'load' and 'preload'. "
+                "Use 'load' for standard import or 'preload' for optimized bulk loading."
             )
             raise ValueError(msg)
 
-        payload = {"fileNames": file_names}
+        paths = [filenames] if isinstance(filenames, (str, os.PathLike)) else filenames
+        if not paths or (len(paths) == 1 and not paths[0]):
+            msg = (
+                "[GraphDB] bulk_load() received no input paths. "
+                "Expected a file path or a list of paths to RDF files or directories.\n"
+                "Example: bulk_load('data.ttl')"
+            )
+            raise ValueError(msg)
 
-        graph = target_graph if target_graph is not None else self.graph_uri
-        if graph:
-            payload["importSettings"] = {"context": graph}
+        normalized_paths: list[str] = []
+        for item in paths:
+            path = Path(item)
+            if not path.exists():
+                msg = (
+                    f"[GraphDB] bulk_load() could not find the input path: '{path}'. "
+                    "Please ensure that the file or directory exists and the path is correct.\n"
+                    "Example: bulk_load('data.ttl') or bulk_load(['/path/to/data.ttl'])"
+                )
+                raise FileNotFoundError(msg)
+            normalized_paths.append(str(path.resolve()))
 
-        import_url = f"{self.base_url}/rest/repositories/{self.repository}/import/server"
+        repo_id = repository_id or self.repository
+
+        graphdb_home = os.environ.get("GRAPHDB_HOME")
+        if graphdb_home:
+            importrdf = Path(graphdb_home).expanduser().resolve() / "bin" / "importrdf"
+            if not importrdf.exists():
+                msg = (
+                    f"[GraphDB] 'GRAPHDB_HOME' is set to '{graphdb_home}', but the 'importrdf' "
+                    f"executable was not found at: {importrdf}.\n"
+                    "Ensure that GRAPHDB_HOME points to a valid GraphDB installation directory "
+                    "containing 'bin/importrdf'."
+                )
+                raise FileNotFoundError(msg)
+            importrdf_path = str(importrdf)
+        else:
+            importrdf_path = shutil.which("importrdf")
+            if not importrdf_path:
+                msg = (
+                    "[GraphDB] Unable to locate the 'importrdf' executable.\n"
+                    "Set the 'GRAPHDB_HOME' environment variable to your GraphDB installation directory "
+                    "or ensure that 'importrdf' is available on your system PATH."
+                )
+                raise FileNotFoundError(msg)
 
         try:
-            response = requests.post(import_url, json=payload, auth=self.auth, timeout=None)
-        except requests.RequestException as e:
-            msg = f"[GraphDB] Bulk load request failed: {e}"
-            raise RuntimeError(msg) from e
+            response = requests.get(self.base_url, timeout=3, auth=self.auth)
+            if response.ok:
+                msg = (
+                    f"[GraphDB] bulk_load() cannot run while the GraphDB server is active at '{self.base_url}'. "
+                    "The ImportRDF tool requires the server to be fully stopped before execution.\n"
+                    "Please stop the GraphDB server and try again."
+                )
+                raise RuntimeError(msg)
+        except requests.RequestException:
+            pass
 
-        if response.status_code not in {200, 201, 202, 204}:
-            msg = f"[GraphDB] Bulk load failed with status {response.status_code}:\n{response.text}"
-            raise RuntimeError(msg)
+        command = [importrdf_path, mode, "-f", "-i", repo_id]
+        if mode == "load":
+            command.extend(["-m", "parallel"])
+        command.extend(normalized_paths)
+
+        try:
+            subprocess.run(command, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr.strip() if exc.stderr else ""
+            stdout = exc.stdout.strip() if exc.stdout else ""
+            details = stderr or stdout or str(exc)
+            msg = f"[GraphDB] Bulk Load failed:\n{details}"
+            raise RuntimeError(msg) from exc
 
     def add(self, s: Any, p: Any, o: Any) -> None:
         """
@@ -253,6 +311,8 @@ class GraphDB(TriplestoreBackend):
         if export:
             chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="GraphDB")
 
+        self._ensure_repository_exists()
+
         response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
 
         if response.status_code != 200:
@@ -300,6 +360,8 @@ class GraphDB(TriplestoreBackend):
         """
         query_type = get_sparql_query_type(sparql)
         chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="GraphDB")
+
+        self._ensure_repository_exists()
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:
@@ -370,6 +432,8 @@ class GraphDB(TriplestoreBackend):
         RuntimeError
             If the update operation fails with a non-success status code.
         """
+        self._ensure_repository_exists()
+
         response = requests.post(self.update_url, headers=self.headers_update, data=sparql, auth=self.auth, timeout=None)
         if response.status_code not in {200, 204, 201}:
             msg = f"[GraphDB] SPARQL update failed: {response.status_code}\n{response.text}"
@@ -385,7 +449,7 @@ class GraphDB(TriplestoreBackend):
         RuntimeError
             If unable to connect to the server or if repository creation fails.
         """
-        check_url = f"{self.base_url}/repositories/{self.repository}"
+        check_url = f"{self.base_url}/rest/repositories/{self.repository}"
 
         try:
             response = requests.get(check_url, timeout=300, auth=self.auth)
@@ -407,13 +471,6 @@ class GraphDB(TriplestoreBackend):
         except requests.RequestException as e:
             msg = f"[GraphDB] Could not connect to GraphDB at {check_url}: {e}"
             raise RuntimeError(msg) from e
-
-        try:
-            delete_url = f"{self.base_url}/repositories/{self.repository}"
-            requests.delete(delete_url, timeout=300, auth=self.auth)
-        except requests.RequestException as err:
-            msg = f"[GraphDB] Failed to delete repo {self.repository} silently: {err}"
-            logger.debug(msg)
 
         create_url = f"{self.base_url}/rest/repositories"
 

--- a/triplestore/src/triplestore/backends/graphdb.py
+++ b/triplestore/src/triplestore/backends/graphdb.py
@@ -16,6 +16,7 @@ from triplestore.utils import (
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
+    validate_rdf_term,
 )
 
 logger = logging.getLogger(__name__)
@@ -149,19 +150,23 @@ class GraphDB(TriplestoreBackend):
             msg = f"[GraphDB] Bulk load failed with status {response.status_code}:\n{response.text}"
             raise RuntimeError(msg)
 
-    def add(self, s: str, p: str, o: str) -> None:
+    def add(self, s: Any, p: Any, o: Any) -> None:
         """
         Add a triple to the GraphDB store.
 
         Parameters:
-        s : str
-            The subject URI of the triple.
-        p : str
-            The predicate URI of the triple.
-        o : str
-            The object URI of the triple.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "GraphDB")
+        p_term = validate_rdf_term(p, "predicate", "GraphDB")
+        o_term = validate_rdf_term(o, "object", "GraphDB")
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri else
@@ -169,19 +174,39 @@ class GraphDB(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def delete(self, s: str, p: str, o: str) -> None:
+    def delete(self, s: Any, p: Any, o: Any) -> None:
         """
         Delete a triple from the GraphDB store.
 
         Parameters:
-        s : str
-            The subject URI of the triple to remove.
-        p : str
-            The predicate URI of the triple to remove.
-        o : str
-            The object URI of the triple to remove.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
+
+        Raises
+        ------
+        ValueError
+            If a blank node is provided as the subject.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "GraphDB")
+        p_term = validate_rdf_term(p, "predicate", "GraphDB")
+        o_term = validate_rdf_term(o, "object", "GraphDB")
+
+        if isinstance(s, str) and s.startswith("_:"):
+            msg = (
+                "[GraphDB] Cannot delete triples using a blank node as subject.\n\n"
+                "Blank node identifiers (e.g. '_:b1') are local to a single SPARQL query "
+                "or update and do not represent stable, reusable identifiers.\n"
+                "Recommended alternatives:\n"
+                " - Use a persistent IRI instead of a blank node if you need to delete the triple later.\n"
+                " - Or delete using a pattern-based query (e.g. DELETE WHERE) that matches the triple.\n\n"
+            )
+            raise ValueError(msg)
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri else

--- a/triplestore/src/triplestore/backends/graphdb.py
+++ b/triplestore/src/triplestore/backends/graphdb.py
@@ -8,7 +8,15 @@ from typing import Any
 import requests
 
 from triplestore.base import TriplestoreBackend
-from triplestore.utils import detect_graphdb_url, validate_config
+from triplestore.utils import (
+    detect_graphdb_url,
+    export_ask_result,
+    export_rdf_result,
+    export_select_results,
+    get_sparql_query_type,
+    resolve_export_format,
+    validate_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +84,8 @@ class GraphDB(TriplestoreBackend):
 
         Raises
         ------
+        FileNotFoundError
+            If the input file does not exist.
         RuntimeError
             If the server returns an error status during data loading.
         """
@@ -133,13 +143,21 @@ class GraphDB(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def query(self, sparql: str) -> list[dict[str, str]]:
+    def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
         """
         Execute a SPARQL query against the GraphDB repository.
 
         Parameters:
         sparql : str
             The SPARQL query string.
+        export : bool, optional
+            If True, also save the query results to a local file.
+        output_format : str, optional
+            Export format for saved results. Supported: 'json', 'csv'.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
         Returns:
         list of dict
@@ -147,9 +165,23 @@ class GraphDB(TriplestoreBackend):
 
         Raises
         ------
+        ValueError
+            If query() is called with a non-SELECT query or with an unsupported export format.
         RuntimeError
             If the query fails or the server returns an error response.
         """
+        query_type = get_sparql_query_type(sparql)
+
+        if query_type != "SELECT":
+            msg = (f"[GraphDB] Unsupported query type '{query_type}' for query(). "
+                "Only SELECT queries are supported. "
+                "Use execute() for UPDATE queries or other query forms."
+            )
+            raise ValueError(msg)
+
+        if export:
+            chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="GraphDB")
+
         response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
 
         if response.status_code != 200:
@@ -158,9 +190,14 @@ class GraphDB(TriplestoreBackend):
 
         data = response.json()
         bindings = data.get("results", {}).get("bindings", [])
-        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+        results = [{k: v["value"] for k, v in row.items()} for row in bindings]
 
-    def execute(self, sparql: str) -> Any:
+        if export:
+            export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="GraphDB")
+
+        return results
+
+    def execute(self, sparql: str, *, export: bool = False, output_format: str | None = None, filename: str | None = None, separator: str = ",") -> Any:
         """
         Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
 
@@ -168,6 +205,14 @@ class GraphDB(TriplestoreBackend):
         ----------
         sparql : str
             The SPARQL query or update string.
+        export : bool, optional
+            If True, also save the query result to a local file.
+        output_format : str, optional
+            Export format for saved results. If omitted and export=True, a default format is chosen based on the query type.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
         Returns
         -------
@@ -182,38 +227,46 @@ class GraphDB(TriplestoreBackend):
         RuntimeError
             If the server responds with an error status.
         """
-        # qstrip = sparql.lstrip()
-        # query_type = qstrip.split(None, 1)[0].upper() if qstrip else ""
-
-        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
-
-        query_type = ""
-        for line in lines:
-            upper = line.upper()
-            if upper.startswith("PREFIX ") or upper.startswith("BASE "):
-                continue
-            query_type = line.split(None, 1)[0].upper()
-            break
+        query_type = get_sparql_query_type(sparql)
+        chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="GraphDB")
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:
             response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[GraphDB] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
+
             data = response.json()
+
             if query_type == "ASK":
-                return bool(data.get("boolean", False))
+                result = bool(data.get("boolean", False))
+                if export:
+                    export_ask_result(result, output_format=chosen_format, filename=filename, backend_name="GraphDB")
+                return result
+
             bindings = data.get("results", {}).get("bindings", [])
-            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+            results = [{k: v["value"] for k, v in row.items()} for row in bindings]
+            if export:
+                export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="GraphDB")
+
+            return results
 
         # CONSTRUCT / DESCRIBE
         if query_type in {"CONSTRUCT", "DESCRIBE"}:
             response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": sparql}, auth=self.auth, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[GraphDB] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
-            return response.text
+
+            rdf_text = response.text
+
+            if export:
+                export_rdf_result(rdf_text, output_format=chosen_format, filename=filename, backend_name="GraphDB")
+
+            return rdf_text
 
         #  UPDATE operations (INSERT, DELETE, CLEAR, DROP, LOAD, CREATE, etc.)
         if query_type in {
@@ -230,10 +283,7 @@ class GraphDB(TriplestoreBackend):
         """
         Remove all data from the GraphDB repository (default and named graphs).
         """
-        if getattr(self, "graph_uri", None):
-            sparql = f"CLEAR GRAPH <{self.graph_uri}>"
-        else:
-            sparql = "CLEAR DEFAULT"
+        sparql = f"CLEAR GRAPH <{self.graph_uri}>" if getattr(self, "graph_uri", None) else "CLEAR DEFAULT"
         self._run_update(sparql)
 
     def _run_update(self, sparql: str) -> None:

--- a/triplestore/src/triplestore/backends/graphdb.py
+++ b/triplestore/src/triplestore/backends/graphdb.py
@@ -103,6 +103,52 @@ class GraphDB(TriplestoreBackend):
             msg = f"[GraphDB] Load failed with status {response.status_code}:\n{response.text}"
             raise RuntimeError(msg)
 
+    def bulk_load(self, filenames: str | list[str], *, target_graph: str | None = None) -> None:
+        """
+        Bulk-load one or more RDF files that already exist on the GraphDB server.
+
+        Parameters
+        ----------
+        filenames : str or list[str]
+            Server-side file path(s), relative to the GraphDB import directory.
+        target_graph : str, optional
+            Named graph URI for this import. If omitted, the graph configured for this backend
+            instance is used. If neither is set, GraphDB uses its default import behavior.
+
+        Raises
+        ------
+        ValueError
+            If no server-side file paths are provided.
+        RuntimeError
+            If the bulk-load request fails or the server returns a non-success status.
+        """
+        file_names = [filenames] if isinstance(filenames, str) else [name for name in filenames if name]
+
+        if not file_names:
+            msg = (
+                "[GraphDB] bulk_load() requires at least one non-empty server-side file path. "
+                "Ensure that the file exists in the GraphDB import directory."
+            )
+            raise ValueError(msg)
+
+        payload = {"fileNames": file_names}
+
+        graph = target_graph if target_graph is not None else self.graph_uri
+        if graph:
+            payload["importSettings"] = {"context": graph}
+
+        import_url = f"{self.base_url}/rest/repositories/{self.repository}/import/server"
+
+        try:
+            response = requests.post(import_url, json=payload, auth=self.auth, timeout=None)
+        except requests.RequestException as e:
+            msg = f"[GraphDB] Bulk load request failed: {e}"
+            raise RuntimeError(msg) from e
+
+        if response.status_code not in {200, 201, 202, 204}:
+            msg = f"[GraphDB] Bulk load failed with status {response.status_code}:\n{response.text}"
+            raise RuntimeError(msg)
+
     def add(self, s: str, p: str, o: str) -> None:
         """
         Add a triple to the GraphDB store.

--- a/triplestore/src/triplestore/backends/graphdb.py
+++ b/triplestore/src/triplestore/backends/graphdb.py
@@ -16,6 +16,7 @@ from triplestore.utils import (
     export_ask_result,
     export_rdf_result,
     export_select_results,
+    get_rdf_content_type,
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
@@ -78,11 +79,15 @@ class GraphDB(TriplestoreBackend):
 
     def load(self, filename: str) -> None:
         """
-        Load RDF triples from a Turtle (.ttl) file into the GraphDB repository.
+        Load RDF triples from a supported RDF file into the GraphDB repository.
+
+        Supported formats:
+        - .ttl: Turtle
+        - .nt: N-Triples
 
         Parameters:
         filename : str
-            Path to the Turtle (.ttl) file to be loaded.
+            Path to the RDF file to load (.ttl or .nt).
 
         Raises
         ------
@@ -95,13 +100,16 @@ class GraphDB(TriplestoreBackend):
             msg = f"[GraphDB] File not found: {filename}"
             raise FileNotFoundError(msg)
 
+        content_type = get_rdf_content_type(filename, backend_name="GraphDB")
+        headers = {"Content-Type": content_type}
+
         self._ensure_repository_exists()
 
         rdf_data = Path(filename).read_bytes()
         params = {}
         if self.graph_uri:
             params["context"] = f"<{self.graph_uri}>"
-        response = requests.post(self.update_url, headers=self.headers_load, params=params, data=rdf_data, auth=self.auth, timeout=None)
+        response = requests.post(self.update_url, headers=headers, params=params, data=rdf_data, auth=self.auth, timeout=None)
 
         if response.status_code not in {200, 204, 201}:
             msg = f"[GraphDB] Load failed with status {response.status_code}:\n{response.text}"

--- a/triplestore/src/triplestore/backends/graphdb.py
+++ b/triplestore/src/triplestore/backends/graphdb.py
@@ -182,8 +182,18 @@ class GraphDB(TriplestoreBackend):
         RuntimeError
             If the server responds with an error status.
         """
-        qstrip = sparql.lstrip()
-        query_type = qstrip.split(None, 1)[0].upper() if qstrip else ""
+        # qstrip = sparql.lstrip()
+        # query_type = qstrip.split(None, 1)[0].upper() if qstrip else ""
+
+        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
+
+        query_type = ""
+        for line in lines:
+            upper = line.upper()
+            if upper.startswith("PREFIX ") or upper.startswith("BASE "):
+                continue
+            query_type = line.split(None, 1)[0].upper()
+            break
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:
@@ -303,7 +313,7 @@ class GraphDB(TriplestoreBackend):
             graphdb:enable-predicate-list "true"^^xsd:boolean ;
             graphdb:in-memory-literal-properties "false"^^xsd:boolean ;
             graphdb:enable-literal-index "true"^^xsd:boolean ;
-            graphdb:enable-geo-spatial "false"^^xsd:boolean ;
+            graphdb:enable-geo-spatial "true"^^xsd:boolean ;
             graphdb:enable-full-text-search "false"^^xsd:boolean ;
             graphdb:fts-index-policy "ALL" ;
             graphdb:strict-parsing "true"^^xsd:boolean ;

--- a/triplestore/src/triplestore/backends/jena.py
+++ b/triplestore/src/triplestore/backends/jena.py
@@ -11,9 +11,16 @@ from urllib.parse import urlparse
 
 import requests
 
-from triplestore.backends.jena_utils import add_graph_clause_if_needed, first_keyword, start_fuseki_server, stop_fuseki_server
+from triplestore.backends.jena_utils import add_graph_clause_if_needed, start_fuseki_server, stop_fuseki_server
 from triplestore.base import TriplestoreBackend
-from triplestore.utils import validate_config
+from triplestore.utils import (
+    export_ask_result,
+    export_rdf_result,
+    export_select_results,
+    get_sparql_query_type,
+    resolve_export_format,
+    validate_config,
+)
 
 
 class Jena(TriplestoreBackend):
@@ -146,23 +153,48 @@ class Jena(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def query(self, sparql: str) -> list[dict[str, str]]:
+    def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
         """
-        Execute a SPARQL query against the Jena dataset.
+        Execute a SPARQL SELECT query against the Jena dataset.
 
-        Parameters:
+        Parameters
+        ----------
         sparql : str
             The SPARQL query string.
+        export : bool, optional
+            If True, also save the query results to a local file.
+        output_format : str, optional
+            Export format for saved results. Supported: 'json', 'csv'.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
-        Returns:
-        list of dict
+        Returns
+        -------
+        list[dict[str, str]]
             The list of query result bindings.
 
         Raises
         ------
+        ValueError
+            If query() is called with a non-SELECT query or with an unsupported export format.
         RuntimeError
             If the query fails or the server returns an error response.
         """
+        query_type = get_sparql_query_type(sparql)
+
+        if query_type != "SELECT":
+            msg = (
+                f"[APACHE JENA] Unsupported query type '{query_type}' for query(). "
+                "Only SELECT queries are supported. "
+                "Use execute() for UPDATE queries or other query forms."
+            )
+            raise ValueError(msg)
+
+        if export:
+            chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="APACHE JENA")
+
         final_query = (
             add_graph_clause_if_needed(sparql, self._effective_graph)
             if getattr(self, "_effective_graph", None) == "urn:app:default"
@@ -177,23 +209,36 @@ class Jena(TriplestoreBackend):
 
         data = response.json()
         bindings = data.get("results", {}).get("bindings", [])
-        return [
-            {k: v["value"] for k, v in row.items()}
-            for row in bindings
-        ]
+        results = [{k: v["value"] for k, v in row.items()} for row in bindings]
 
-    def execute(self, sparql: str) -> Any:
+        if export:
+            export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="APACHE JENA")
+
+        return results
+
+    def execute(self, sparql: str, *, export: bool = False, output_format: str | None = None, filename: str | None = None, separator: str = ",") -> Any:
         """
         Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
 
-        Parameters:
+        Parameters
+        ----------
         sparql : str
             The SPARQL query or update string.
+        export : bool, optional
+            If True, also save the query result to a local file.
+        output_format : str, optional
+            Export format for saved results. If omitted and export=True, a default format is chosen based on the query type.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
-        Returns:
+        Returns
+        -------
         Any
-            - list of dict for SELECT/ASK
-            - str (raw text) or parsed JSON for CONSTRUCT/DESCRIBE
+            - list of dict for SELECT
+            - bool for ASK
+            - str (Turtle RDF) for CONSTRUCT/DESCRIBE
             - None for UPDATE operations
 
         Raises
@@ -201,46 +246,57 @@ class Jena(TriplestoreBackend):
         RuntimeError
             If the server responds with an error status.
         """
-        kw = first_keyword(sparql)
-        if not kw:
-            msg = "[APACHE JENA] Could not detect SPARQL keyword."
-            raise RuntimeError(msg)
+        query_type = get_sparql_query_type(sparql)
+        chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="APACHE JENA")
 
-        if kw in {"SELECT", "ASK", "CONSTRUCT", "DESCRIBE"} and getattr(self, "_effective_graph", None) == "urn:app:default":
+        if query_type in {"SELECT", "ASK", "CONSTRUCT", "DESCRIBE"} and getattr(self, "_effective_graph", None) == "urn:app:default":
             final_query = add_graph_clause_if_needed(sparql, self._effective_graph)
         else:
             final_query = sparql
 
         # SELECT / ASK
-        if kw in {"SELECT", "ASK"}:
+        if query_type in {"SELECT", "ASK"}:
             response = requests.post(self.query_url, headers=self.headers_query, data={"query": final_query}, auth=self.auth, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[APACHE JENA] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
+
             data = response.json()
-            if kw == "ASK":
-                return bool(data.get("boolean", False))
+
+            if query_type == "ASK":
+                result = bool(data.get("boolean", False))
+                if export:
+                    export_ask_result(result, output_format=chosen_format, filename=filename, backend_name="APACHE JENA")
+                return result
 
             bindings = data.get("results", {}).get("bindings", [])
-            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+            results = [{k: v["value"] for k, v in row.items()} for row in bindings]
+            if export:
+                export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="APACHE JENA")
 
-        #  CONSTRUCT / DESCRIBE (graph queries → RDF)
-        if kw in {"CONSTRUCT", "DESCRIBE"}:
+            return results
+
+        # CONSTRUCT / DESCRIBE
+        if query_type in {"CONSTRUCT", "DESCRIBE"}:
             response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": final_query}, auth=self.auth, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[APACHE JENA] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
-            return response.text
 
-        # UPDATE family (INSERT, DELETE, CLEAR, LOAD, CREATE, DROP, MOVE, COPY, ADD, MODIFY, WITH)
-        if kw in {"WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP", "MOVE", "COPY", "ADD", "MODIFY"}:
-            response = requests.post(self.update_url, headers=self.headers_update, data=sparql, auth=self.auth, timeout=None)
-            if response.status_code not in {200, 204}:
-                msg = f"[APACHE JENA] Update failed {response.status_code}:\n{response.text}"
-                raise RuntimeError(msg)
+            rdf_text = response.text
+            if export:
+                export_rdf_result(rdf_text, output_format=chosen_format, filename=filename, backend_name="APACHE JENA")
+
+            return rdf_text
+
+        # UPDATE family
+        if query_type in {"WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP", "MOVE", "COPY", "ADD", "MODIFY"}:
+            self._run_update(sparql)
             return None
 
-        msg = f"[APACHE JENA] Unsupported SPARQL keyword: {kw}"
+        msg = f"[APACHE JENA] Unsupported SPARQL keyword: {query_type}"
         raise RuntimeError(msg)
 
     def clear(self) -> None:

--- a/triplestore/src/triplestore/backends/jena.py
+++ b/triplestore/src/triplestore/backends/jena.py
@@ -20,6 +20,7 @@ from triplestore.utils import (
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
+    validate_rdf_term,
 )
 
 
@@ -129,25 +130,60 @@ class Jena(TriplestoreBackend):
             except Exception:
                 pass
 
-    def add(self, s: str, p: str, o: str) -> None:
+    def add(self, s: Any, p: Any, o: Any) -> None:
         """
         Add a triple to the Jena store.
 
-        Uses the named graph if specified in the config.
+        Parameters:
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "APACHE JENA")
+        p_term = validate_rdf_term(p, "predicate", "APACHE JENA")
+        o_term = validate_rdf_term(o, "object", "APACHE JENA")
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"INSERT DATA {{ GRAPH <{self._effective_graph}> {{ {triple} }} }}"
         )
         self._run_update(sparql)
 
-    def delete(self, s: str, p: str, o: str) -> None:
+    def delete(self, s: Any, p: Any, o: Any) -> None:
         """
         Delete a triple from the Jena store.
 
-        Uses the named graph if specified in the config.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
+
+        Raises
+        ------
+        ValueError
+            If a blank node is provided as the subject.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "APACHE JENA")
+        p_term = validate_rdf_term(p, "predicate", "APACHE JENA")
+        o_term = validate_rdf_term(o, "object", "APACHE JENA")
+
+        if isinstance(s, str) and s.startswith("_:"):
+            msg = (
+                "[APACHE JENA] Cannot delete triples using a blank node as subject.\n\n"
+                "Blank node identifiers (e.g. '_:b1') are local to a single SPARQL query "
+                "or update and do not represent stable, reusable identifiers.\n"
+                "Recommended alternatives:\n"
+                " - Use a persistent IRI instead of a blank node if you need to delete the triple later.\n"
+                " - Or delete using a pattern-based query (e.g. DELETE WHERE) that matches the triple.\n\n"
+            )
+            raise ValueError(msg)
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"DELETE DATA {{ GRAPH <{self._effective_graph}> {{ {triple} }} }}"
         )

--- a/triplestore/src/triplestore/backends/jena.py
+++ b/triplestore/src/triplestore/backends/jena.py
@@ -7,10 +7,11 @@ import shutil
 import tempfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 
-from triplestore.backends.jena_utils import add_graph_clause_if_needed, create_config_and_run_fuseki, first_keyword, stop_fuseki_server
+from triplestore.backends.jena_utils import add_graph_clause_if_needed, first_keyword, start_fuseki_server, stop_fuseki_server
 from triplestore.base import TriplestoreBackend
 from triplestore.utils import validate_config
 
@@ -50,7 +51,11 @@ class Jena(TriplestoreBackend):
         self.base_url = configuration["base_url"]
         self.dataset = configuration["name"]
 
-        create_config_and_run_fuseki(self.dataset)
+        parsed = urlparse(self.base_url)
+        host = parsed.hostname or "localhost"
+        port = parsed.port or 3030
+
+        start_fuseki_server(self.dataset, host, port)
         self.auth = configuration["auth"]
         self.graph_uri = configuration["graph"]
         if self.graph_uri:
@@ -66,7 +71,7 @@ class Jena(TriplestoreBackend):
         self.headers_query = {"Accept": "application/sparql-results+json"}
         self.headers_update = {"Content-Type": "application/sparql-update"}
 
-        self._ensure_dataset_exists()
+        #self._ensure_dataset_exists()
 
     def load(self, filename: str) -> None:
         """
@@ -80,6 +85,8 @@ class Jena(TriplestoreBackend):
 
         Raises
         ------
+        FileNotFoundError
+            If the file does not exist.
         RuntimeError
             If the server returns an error status during data loading.
         """
@@ -317,4 +324,12 @@ class Jena(TriplestoreBackend):
             raise RuntimeError(msg)
 
     def stop_server(self) -> bool:
+        """
+        Stop running local Fuseki server processes.
+
+        Returns
+        -------
+        bool
+            True if at least one matching process was found, otherwise False.
+        """
         return stop_fuseki_server()

--- a/triplestore/src/triplestore/backends/jena.py
+++ b/triplestore/src/triplestore/backends/jena.py
@@ -17,6 +17,7 @@ from triplestore.utils import (
     export_ask_result,
     export_rdf_result,
     export_select_results,
+    get_rdf_content_type,
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
@@ -83,13 +84,13 @@ class Jena(TriplestoreBackend):
 
     def load(self, filename: str) -> None:
         """
-        Load RDF triples from a Turtle (.ttl) file into the Jena dataset.
+        Load RDF triples from a supported RDF file into the Jena dataset.
 
         If a named graph URI is provided in the configuration, data is loaded into that graph.
 
         Parameters:
         filename : str
-            Path to the Turtle (.ttl) file to be loaded.
+            Path to the RDF file to load (.ttl or .nt).
 
         Raises
         ------
@@ -102,10 +103,12 @@ class Jena(TriplestoreBackend):
         if not path.exists():
             msg = f"[APACHE JENA] File not found: {filename}"
             raise FileNotFoundError(msg)
+        
+        content_type = get_rdf_content_type(filename, backend_name="APACHE JENA")
 
         params = {"graph": self._effective_graph}
 
-        tmp_gz = tempfile.NamedTemporaryFile(prefix="ttl-", suffix=".ttl.gz", delete=False)
+        tmp_gz = tempfile.NamedTemporaryFile(prefix="rdf-", suffix=f"{path.suffix}.gz", delete=False)
         tmp_gz_path = Path(tmp_gz.name)
         try:
             with path.open("rb") as fin, gzip.open(tmp_gz, "wb", compresslevel=9) as fout:
@@ -113,7 +116,7 @@ class Jena(TriplestoreBackend):
             tmp_gz.close()
 
             headers = {
-                "Content-Type": "text/turtle",
+                "Content-Type": content_type,
                 "Content-Encoding": "gzip",
                 "Connection": "keep-alive",
             }

--- a/triplestore/src/triplestore/backends/jena_utils.py
+++ b/triplestore/src/triplestore/backends/jena_utils.py
@@ -322,15 +322,3 @@ def add_graph_clause_if_needed(q: str, graph: str) -> str:
         + " }"
         + q[close_idx:]
     )
-
-
-def first_keyword(q: str) -> str:
-    q = re.sub(r"(^|\n)\s*#.*", "", q)
-
-    q = re.sub(r"^\s*(BASE|PREFIX)\b[^\n]*\n", "", q, flags=re.IGNORECASE | re.MULTILINE)
-
-    m = re.search(
-        r"\b(SELECT|ASK|CONSTRUCT|DESCRIBE|WITH|INSERT|DELETE|LOAD|CLEAR|CREATE|DROP|MOVE|COPY|ADD|MODIFY)\b",
-        q, flags=re.IGNORECASE
-    )
-    return m.group(1).upper() if m else ""

--- a/triplestore/src/triplestore/backends/jena_utils.py
+++ b/triplestore/src/triplestore/backends/jena_utils.py
@@ -7,7 +7,6 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from textwrap import dedent
 
 import psutil
 import requests
@@ -15,8 +14,21 @@ import requests
 
 def sanitize_fuseki_dataset_name(name: str) -> str:
     """
-    Convert a dataset name into a Fuseki path-safe service name:
-    keep [A-Za-z0-9_-], collapse everything else to '-'.
+    Sanitize a dataset name so it can be safely used as a Fuseki service name.
+
+    The function preserves only alphanumeric characters, underscores, and hyphens.
+    Any consecutive run of unsupported characters is replaced with a single hyphen.
+    If the resulting name is empty, the default value ``"ds"`` is returned.
+
+    Parameters
+    ----------
+    name : str
+        Raw dataset name provided by the user.
+
+    Returns
+    -------
+    str
+        A sanitized dataset name suitable for use in Fuseki service paths.
     """
     cleaned = re.sub(r"[^A-Za-z0-9_-]+", "-", name.strip())
     return cleaned.strip("-") or "ds"
@@ -24,12 +36,18 @@ def sanitize_fuseki_dataset_name(name: str) -> str:
 
 def create_tdb2_location() -> Path:
     """
-    Compute the TDB2 directory for the current user.
+    Determine the directory where the local TDB2 dataset files will be stored.
 
     Rules:
-    - If FUSEKI_BASE is set -> use sibling folder 'DB2', i.e., dirname(FUSEKI_BASE)/DB2
-    - Otherwise -> fallback to ~/fuseki/DB2
-    The directory is created if missing.
+    - If the environment variable ``FUSEKI_BASE`` is set, the TDB2 directory
+      is created as a sibling folder named ``DB2`` next to it.
+    - Otherwise, the default location ``~/fuseki/DB2`` is used.
+    The directory is created automatically if it does not already exist.
+
+    Returns
+    -------
+    str
+        Path to the TDB2 storage directory.
     """
     fb = os.environ.get("FUSEKI_BASE")
     if fb:
@@ -41,34 +59,22 @@ def create_tdb2_location() -> Path:
     return tdb2
 
 
-def create_config_path() -> Path:
-    """
-    Decide where to write config.ttl:
-
-    - If FUSEKI_BASE is set -> inside it (FUSEKI_BASE/config.ttl)
-    - Else -> ~/fuseki/base/config.ttl
-
-    The directory is created if missing.
-    """
-    fb = os.environ.get("FUSEKI_BASE")
-    if fb:
-        base = Path(fb).expanduser().resolve()
-    else:
-        base = Path.home() / "fuseki" / "base"
-    base.mkdir(parents=True, exist_ok=True)
-    return base / "config.ttl"
-
-
 def find_fuseki_server() -> str:
     """
-    Locate the 'fuseki-server' executable.
-
+    Locate the 'fuseki-server' executable in the current environment.
     Search order:
-    1) $FUSEKI_HOME/fuseki-server  (if FUSEKI_HOME is set)
+    1) If the environment variable $FUSEKI_HOME is defined and, if so, looks for the executable inside that directory.
     2) PATH lookup via shutil.which('fuseki-server')
 
+    Returns
+    -------
+    str
+        Absolute path to the located `fuseki-server` executable.
+
     Raises:
-        FileNotFoundError if not found.
+    ------
+    FileNotFoundError
+        If the `fuseki-server` executable cannot be found in either `FUSEKI_HOME` or the system `PATH`.
     """
     fh = os.environ.get("FUSEKI_HOME")
     if fh:
@@ -102,98 +108,175 @@ def find_fuseki_server() -> str:
     raise FileNotFoundError(msg)
 
 
-def create_config_and_run_fuseki(dataset_name: str, show_server_logs: bool = False) -> Path:
+def find_jena_geosparql_jar() -> str:
     """
-    Create a minimal Fuseki config.ttl for a TDB2-backed dataset and launch Fuseki.
+    Locate the `jena-fuseki-geosparql` jar file in the current environment.
+    Search order:
+    1) If the environment variable $JENA_GEOSPARQL_JAR is defined and points to an existing jar file.
+    2) If $FUSEKI_HOME/lib/jena-fuseki-geosparql-*.jar exists.
+    3) Attempts to locate the `fuseki-server` executable and then looks for the jar inside the adjacent `lib` directory.
 
-    The config exposes the endpoints: query, update, data (GSP RW), upload.
+    Returns
+    -------
+    str
+        Absolute path to the located `jena-fuseki-geosparql` jar file.
 
-    Args:
-        dataset_name: Desired dataset/service name (will be sanitized for URL path).
-        show_server_logs: If True, forward server stdout/stderr to the terminal.
-                          If False (default), silence server output.
+    Raises
+    ------
+    FileNotFoundError
+        If the jar file cannot be found, or if `JENA_GEOSPARQL_JAR` is set but points to a non-existent file.
+    """
+    env_jar = os.environ.get("JENA_GEOSPARQL_JAR")
+    if env_jar:
+        p = Path(env_jar).expanduser().resolve()
+        if p.exists():
+            return str(p)
+        msg = (
+            "\n[APACHE JENA] "
+            "The environment variable 'JENA_GEOSPARQL_JAR' is set, but the file it points to was not found.\n\n"
+            f"Current value:\n  {p}\n\n"
+            "What this means:\n"
+            "  The library tried to use the path from 'JENA_GEOSPARQL_JAR', but no jar file exists there.\n\n"
+            "How to fix:\n"
+            "  • Check that the path is correct and that the jar file really exists there.\n OR\n"
+            "  • Update JENA_GEOSPARQL_JAR so it points to the correct 'jena-fuseki-geosparql-<version>.jar' file.\n OR\n"
+            "  • Remove JENA_GEOSPARQL_JAR and place the jar under '$FUSEKI_HOME/lib/' instead.\n\n"
+            "Examples (Linux/macOS):\n"
+            '  export JENA_GEOSPARQL_JAR="/path/to/jena-fuseki-geosparql-<version>.jar"\n'
+            '  ls -l "$JENA_GEOSPARQL_JAR"\n\n'
+            "Examples (Windows PowerShell):\n"
+            "  $env:JENA_GEOSPARQL_JAR='C:\\\\path\\\\to\\\\jena-fuseki-geosparql-<version>.jar'\n"
+            "  Get-Item $env:JENA_GEOSPARQL_JAR\n"
+        )
+        raise FileNotFoundError(msg)
+
+    candidates: list[Path] = []
+
+    fh = os.environ.get("FUSEKI_HOME")
+    if fh:
+        candidates.extend(sorted((Path(fh).expanduser().resolve() / "lib").glob("jena-fuseki-geosparql-*.jar")))
+
+    try:
+        fuseki = Path(find_fuseki_server()).expanduser().resolve()
+        candidates.extend(sorted((fuseki.parent / "lib").glob("jena-fuseki-geosparql-*.jar")))
+    except FileNotFoundError:
+        pass
+
+    for cand in candidates:
+        if cand.exists():
+            return str(cand)
+
+    msg = (
+    "\n[APACHE JENA] "
+    "Unable to locate the 'jena-fuseki-geosparql' jar file.\n"
+    "How to fix:\n"
+    "  • Set JENA_GEOSPARQL_JAR to the full path of the jar file.\n OR\n"
+    "  • Ensure the jar exists under $FUSEKI_HOME/lib/.\n OR\n"
+    "  • Ensure the jar is installed under the lib/ directory next to the 'fuseki-server' executable.\n\n"
+    "Expected jar name:\n"
+    "  jena-fuseki-geosparql-<version>.jar\n\n"
+    "Examples (Linux/macOS):\n"
+    '  export JENA_GEOSPARQL_JAR="/path/to/jena-fuseki-geosparql-<version>.jar"\n'
+    '  export FUSEKI_HOME="/path/to/apache-jena-fuseki-<version>"\n'
+    '  ls "$FUSEKI_HOME/lib" | grep jena-fuseki-geosparql\n\n'
+    "Examples (Windows PowerShell):\n"
+    "  $env:JENA_GEOSPARQL_JAR='C:\\\\path\\\\to\\\\jena-fuseki-geosparql-<version>.jar'\n"
+    "  $env:FUSEKI_HOME='C:\\\\path\\\\to\\\\apache-jena-fuseki-<version>'\n"
+    '  Get-ChildItem "$env:FUSEKI_HOME\\lib" | Select-String jena-fuseki-geosparql\n\n'
+    "If the issue persists, verify that the jar file exists, that the path is correct, "
+    "and that you have permission to access the file and its directory."
+    )
+    raise FileNotFoundError(msg)
+
+
+def start_fuseki_server(dataset_name: str, host: str = "localhost", port: int = 3030, *, show_server_logs: bool = False) -> Path:
+    """
+    Start a local SPARQL/GeoSPARQL-enabled Fuseki server backed by a TDB2 dataset directory.
+
+    Parameters:
+    -------
+    dataset_name: str
+        Name of the dataset/service to be created. The value is sanitized before being used in the Fuseki service path.
+    host : str, default="localhost"
+        Host used to build the readiness-check query endpoint.
+    port : int, default=3030
+        Port on which the Fuseki server should listen.
+    show_server_logs: bool, default=False
+        If True, forward server stdout/stderr to the terminal.
+        If False (default), silence server output.
 
     Returns:
-        Path to the written config.ttl.
+    -------
+    str
+        Path to the TDB2 dataset directory used by the server.
 
     Raises:
-        RuntimeError if the server does not become ready within the startup timeout.
-        FileNotFoundError if 'fuseki-server' cannot be located.
+    -------
+    RuntimeError
+        If the server does not become ready within the startup timeout.
     """
     service = sanitize_fuseki_dataset_name(dataset_name)
     tdb2_loc = create_tdb2_location()
-    config_path = create_config_path()
+    dataset_dir = tdb2_loc / service
+    dataset_dir.mkdir(parents=True, exist_ok=True)
 
-    ttl = dedent(f"""
-    PREFIX fuseki:  <http://jena.apache.org/fuseki#>
-    PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
-    PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+    geosparql_jar = find_jena_geosparql_jar()
 
-    <#service> a fuseki:Service ;
-      fuseki:name "{service}" ;
-      fuseki:endpoint [ fuseki:operation fuseki:query  ; fuseki:name "query"  ] ;
-      fuseki:endpoint [ fuseki:operation fuseki:update ; fuseki:name "update" ] ;
-      fuseki:endpoint [ fuseki:operation fuseki:gsp_rw ; fuseki:name "data"   ] ;
-      fuseki:endpoint [ fuseki:operation fuseki:upload ; fuseki:name "upload" ] ;
-      fuseki:dataset <#dataset> .
+    env = os.environ.copy()
+    env.setdefault("JAVA_TOOL_OPTIONS", "-Xms4g -Xmx8g")
+    env.setdefault("FUSEKI_BASE", str(Path.home() / "fuseki" / "base"))
+    Path(env["FUSEKI_BASE"]).mkdir(parents=True, exist_ok=True)
 
-    <#dataset> a tdb2:DatasetTDB2 ;
-      tdb2:location "{tdb2_loc.as_posix()}" .
-    """).strip() + "\n"
+    cmd = ["java", "-jar", geosparql_jar, "-p", str(port), "-d", service, "-u", "-t2", "-t", str(dataset_dir), "-i"]
 
-    config_path.write_text(ttl, encoding="utf-8")
-
-    # Sensible defaults for memory (no-op if already set outside)
-    os.environ.setdefault("JAVA_TOOL_OPTIONS", "-Xms4g -Xmx8g")
-
-    fuseki = find_fuseki_server()
-    # Start Fuseki with explicit --config
     if show_server_logs:
-        subprocess.Popen([fuseki, "--config", str(config_path)])
+        subprocess.Popen(cmd, env=env)
     else:
-        subprocess.Popen(
-            [fuseki, "--config", str(config_path)],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL
-        )
+        subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
 
-    base_url = f"http://localhost:3030/{service}/query"
+    query_url = f"http://{host}:{port}/{service}/query"
     timeout = 20
     start_time = time.time()
     while True:
         try:
-            response = requests.post(base_url, data={"query": "ASK {}"}, timeout=2)
+            response = requests.post(query_url, data={"query": "ASK {}"}, timeout=2)
             if response.status_code == 200:
                 print(f"[APACHE JENA] Server is up after {time.time() - start_time:.1f}s.")
                 break
         except requests.RequestException:
             pass
         if time.time() - start_time > timeout:
-            msg = f"[APACHE JENA] Server did not start within {timeout}s."
+            msg = f"[APACHE JENA] Server did not start within {timeout}s on {host}:{port}."
             raise RuntimeError(msg)
         time.sleep(1)
 
-    return config_path
+    return dataset_dir
 
 
 def stop_fuseki_server(timeout: int = 5) -> bool:
     """
-    Stop all running 'fuseki-server' processes on this machine.
+    Stop running Fuseki-related server processes on the current machine.
 
-    This is a broad stop: it does not target a specific dataset/config.
-    It first attempts a graceful terminate(), then force kills if needed.
+    The function scans active system processes and looks for command lines that
+    appear to belong to Apache Jena Fuseki or the GeoSPARQL-enabled Fuseki
+    runtime. Matching processes are first asked to terminate gracefully. If a
+    process does not exit within the given timeout, it is forcefully killed.
 
-    Args:
-        timeout: Seconds to wait for graceful termination before kill().
+    Parameters:
+    ----------
+    timeout: int
+        Number of seconds to wait for graceful termination before forcefully killing a process.
 
     Returns:
+    ----------
         True if at least one process was stopped, False if none was found.
     """
     found = False
     for proc in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
             cmdline = proc.info.get("cmdline") or []
-            if any("fuseki-server" in part for part in cmdline):
+            joined = " ".join(cmdline).lower()
+            if ("fuseki-server" in joined or "jena-fuseki-geosparql" in joined or "org.apache.jena.fuseki" in joined):
                 found = True
                 proc.terminate()
                 try:
@@ -207,38 +290,38 @@ def stop_fuseki_server(timeout: int = 5) -> bool:
 
 
 def add_graph_clause_if_needed(q: str, graph: str) -> str:
-            lower = q.lower()
-            where_idx = lower.find(" where ")
-            if where_idx == -1 or "select" not in lower[:where_idx]:
-                return q
-            try:
-                open_idx = q.index("{", where_idx)
-            except ValueError:
-                return q
+    lower = q.lower()
+    where_idx = lower.find(" where ")
+    if where_idx == -1 or "select" not in lower[:where_idx]:
+        return q
+    try:
+        open_idx = q.index("{", where_idx)
+    except ValueError:
+        return q
 
-            if "graph" in q[open_idx: open_idx + len(q)].lower():
-                return q
+    if "graph" in q[open_idx: open_idx + len(q)].lower():
+        return q
 
-            depth, close_idx = 0, -1
-            for i in range(open_idx, len(q)):
-                ch = q[i]
-                if ch == "{":
-                    depth += 1
-                elif ch == "}":
-                    depth -= 1
-                    if depth == 0:
-                        close_idx = i
-                        break
-            if close_idx == -1:
-                return q
+    depth, close_idx = 0, -1
+    for i in range(open_idx, len(q)):
+        ch = q[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                close_idx = i
+                break
+    if close_idx == -1:
+        return q
 
-            return (
-                q[:open_idx + 1]
-                + f" GRAPH <{graph}> {{"
-                + q[open_idx + 1:close_idx]
-                + " }"
-                + q[close_idx:]
-            )
+    return (
+        q[:open_idx + 1]
+        + f" GRAPH <{graph}> {{"
+        + q[open_idx + 1:close_idx]
+        + " }"
+        + q[close_idx:]
+    )
 
 
 def first_keyword(q: str) -> str:

--- a/triplestore/src/triplestore/backends/oxigraph.py
+++ b/triplestore/src/triplestore/backends/oxigraph.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from pyoxigraph import DefaultGraph, NamedNode, Quad, QueryBoolean, QueryTriples, RdfFormat, Store
+from pyoxigraph import BlankNode, DefaultGraph, Literal, NamedNode, Quad, QueryBoolean, QueryTriples, RdfFormat, Store
 
 from triplestore.base import TriplestoreBackend
 from triplestore.utils import (
@@ -15,6 +16,7 @@ from triplestore.utils import (
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
+    validate_rdf_term,
 )
 
 
@@ -74,36 +76,49 @@ class Oxigraph(TriplestoreBackend):
                 self.store.bulk_load(f, RdfFormat.TURTLE, to_graph=DefaultGraph())
         self.store.optimize()
 
-    def add(self, subject: str, predicate: str, obj: str) -> None:
+    def add(self, subject: Any, predicate: Any, obj: Any) -> None:
         """
         Add a triple to the Oxigraph store.
 
-        Parameters:
-        subject : str
-            The subject URI of the triple.
-        predicate : str
-            The predicate URI of the triple.
-        obj : str
-            The object URI of the triple.
+        Parameters
+        ----------
+        subject : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        predicate : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        obj : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        gterm = NamedNode(self.graph_uri) if self.graph_uri else DefaultGraph()
-        quad = Quad(NamedNode(subject), NamedNode(predicate), NamedNode(obj), gterm)
+        graph_term = NamedNode(self.graph_uri) if self.graph_uri else DefaultGraph()
+        quad = Quad(
+            _to_oxigraph_term(subject, "subject", "Oxigraph"),
+            _to_oxigraph_term(predicate, "predicate", "Oxigraph"),
+            _to_oxigraph_term(obj, "object", "Oxigraph"),
+            graph_term,
+        )
         self.store.add(quad)
 
-    def delete(self, subject: str, predicate: str, obj: str) -> None:
+    def delete(self, subject: Any, predicate: Any, obj: Any) -> None:
         """
         Delete a triple from the Oxigraph store.
 
-        Parameters:
-        subject : str
-            The subject URI of the triple to remove.
-        predicate : str
-            The predicate URI of the triple to remove.
-        obj : str
-            The object URI of the triple to remove.
+        Parameters
+        ----------
+        subject : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        predicate : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        obj : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        gterm = NamedNode(self.graph_uri) if self.graph_uri else DefaultGraph()
-        quad = Quad(NamedNode(subject), NamedNode(predicate), NamedNode(obj), gterm)
+        graph_term = NamedNode(self.graph_uri) if self.graph_uri else DefaultGraph()
+
+        quad = Quad(
+            _to_oxigraph_term(subject, "subject", "Oxigraph"),
+            _to_oxigraph_term(predicate, "predicate", "Oxigraph"),
+            _to_oxigraph_term(obj, "object", "Oxigraph"),
+            graph_term,
+        )
         self.store.remove(quad)
 
     def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
@@ -267,3 +282,65 @@ class Oxigraph(TriplestoreBackend):
             self.store.clear_graph(NamedNode(self.graph_uri))
         else:
             self.store.clear_graph(DefaultGraph())
+
+
+def _to_oxigraph_term(term: Any, position: str, backend_name: str = "Oxigraph"):
+    """
+    Convert a Python value into a corresponding Oxigraph RDF term.
+
+    Parameters
+    ----------
+    term : Any
+        The Python value to convert.
+    position : str
+        The RDF triple position: 'subject', 'predicate', or 'object'.
+    backend_name : str, default="Oxigraph"
+        Backend name used in error messages.
+
+    Returns
+    -------
+    NamedNode | BlankNode | Literal
+        The corresponding Oxigraph RDF term.
+
+    Raises
+    ------
+    ValueError
+        If any triple component is invalid for its RDF position or cannot be converted into a supported Oxigraph RDF term.
+    """
+    validate_rdf_term(term, position, backend_name)
+
+    # Blank node (allowed only for subject and object)
+    if position in {"subject", "object"} and isinstance(term, str) and term.startswith("_:"):
+        return BlankNode(term[2:])
+
+    # IRI or plain string literal
+    if isinstance(term, str):
+        if term.startswith(("http://", "https://")):
+            return NamedNode(term)
+        return Literal(term)
+
+    # Primitive literals
+    if isinstance(term, (bool, int, float)):
+        return Literal(term)
+
+    # Mapping-based literals (typed or language-tagged)
+    if isinstance(term, Mapping):
+        value = term["value"]
+        datatype = term.get("datatype")
+        lang = term.get("lang")
+
+        if datatype is not None:
+            return Literal(str(value), datatype=NamedNode(datatype))
+
+        if lang is not None:
+            return Literal(str(value), language=lang)
+
+        return Literal(str(value))
+
+    # Unsupported type
+    msg = (
+        f"[{backend_name}] Unsupported RDF term: {term!r}\n"
+        "Expected an IRI string, blank node identifier, Python literal, "
+        "or literal mapping."
+    )
+    raise ValueError(msg)

--- a/triplestore/src/triplestore/backends/oxigraph.py
+++ b/triplestore/src/triplestore/backends/oxigraph.py
@@ -8,7 +8,14 @@ from typing import Any
 from pyoxigraph import DefaultGraph, NamedNode, Quad, QueryBoolean, QueryTriples, RdfFormat, Store
 
 from triplestore.base import TriplestoreBackend
-from triplestore.utils import validate_config
+from triplestore.utils import (
+    export_ask_result,
+    export_rdf_result,
+    export_select_results,
+    get_sparql_query_type,
+    resolve_export_format,
+    validate_config,
+)
 
 
 class Oxigraph(TriplestoreBackend):
@@ -49,6 +56,11 @@ class Oxigraph(TriplestoreBackend):
         Parameters:
         filename : str
             Path to the Turtle (.ttl) file to be loaded.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the input file does not exist.
         """
         path = Path(filename)
         if not path.exists():
@@ -94,58 +106,79 @@ class Oxigraph(TriplestoreBackend):
         quad = Quad(NamedNode(subject), NamedNode(predicate), NamedNode(obj), gterm)
         self.store.remove(quad)
 
-    def query(self, sparql: str) -> Any:
+    def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
         """
-        Execute a SPARQL query (SELECT / ASK / CONSTRUCT / DESCRIBE).
+        Execute a SPARQL SELECT query against the Oxigraph store.
 
         Parameters
         ----------
         sparql : str
             A valid SPARQL query string.
+        export : bool, optional
+            If True, also save the query results to a local file.
+        output_format : str, optional
+            Export format for saved results. Supported: 'json', 'csv'.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
         Returns
         -------
-        bool
-            If the query is an ASK, returns True or False.
-        str
-            If the query is a CONSTRUCT or DESCRIBE, returns an RDF graph
-            serialized in Turtle format.
-        list
-            If the query is a SELECT, returns a list of bindings (dictionaries).
-        Any
-            Raw result object if the type cannot be determined.
+        list[dict[str, str]]
+            A list of solution mappings.
+
+        Raises
+        ------
+        ValueError
+            If query() is called with a non-SELECT query or with an unsupported export format.
+        TypeError
+            If the query result is not a valid SELECT result or if the returned result is not iterable.
         """
+        query_type = get_sparql_query_type(sparql)
+
+        if query_type != "SELECT":
+            msg = (
+                f"[Oxigraph] Unsupported query type '{query_type}' for query(). "
+                "Only SELECT queries are supported. "
+                "Use execute() for UPDATE queries or other query forms."
+            )
+            raise ValueError(msg)
+
+        if export:
+            chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="Oxigraph")
+
         result = self.store.query(sparql)
 
-        # ASK
-        if isinstance(result, QueryBoolean):
-            return bool(result)
+        if isinstance(result, (QueryBoolean, QueryTriples)):
+            msg = "[Oxigraph] query() expected a SELECT result but received a different query result type."
+            raise TypeError(msg)
 
-        # CONSTRUCT / DESCRIBE
-        if isinstance(result, QueryTriples):
-            return result.serialize(format=RdfFormat.TURTLE).decode("utf-8")
-
-        # SELECT
         try:
             iter(result)
-        except TypeError:
-            return result
-        else:
-            variable_names = [var.value for var in result.variables]
-            solutions = []
-            for solution in result:
-                binding = {}
-                for var_name in variable_names:
-                    try:
-                        term = solution[var_name]
-                    except KeyError:
-                        continue
-                    term_value = getattr(term, "value", None)
-                    binding[var_name] = term_value if term_value is not None else str(term)
-                solutions.append(binding)
-            return solutions
+        except TypeError as e:
+            msg = "[Oxigraph] query() expected iterable SELECT bindings but got a non-iterable result."
+            raise TypeError(msg) from e
 
-    def execute(self, sparql: str) -> Any:
+        variable_names = [var.value for var in result.variables]
+        solutions: list[dict[str, str]] = []
+        for solution in result:
+            binding: dict[str, str] = {}
+            for var_name in variable_names:
+                try:
+                    term = solution[var_name]
+                except KeyError:
+                    continue
+                term_value = getattr(term, "value", None)
+                binding[var_name] = term_value if term_value is not None else str(term)
+            solutions.append(binding)
+
+        if export:
+            export_select_results(solutions, output_format=chosen_format, filename=filename, separator=separator, backend_name="Oxigraph")
+
+        return solutions
+
+    def execute(self, sparql: str, *, export: bool = False, output_format: str | None = None, filename: str | None = None, separator: str = ",") -> Any:
         """
         Execute any SPARQL operation.
 
@@ -153,30 +186,73 @@ class Oxigraph(TriplestoreBackend):
         ----------
         sparql : str
             A valid SPARQL query or update string.
+        export : bool, optional
+            If True, also save the query result to a local file.
+        output_format : str, optional
+            Export format for saved results. If omitted and export=True, a default format is chosen based on the query type.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
         Returns
         -------
-        None
-            For SPARQL Update operations (INSERT, DELETE, CLEAR, etc.).
-        bool
-            For ASK queries.
-        list
-            For SELECT queries, a list of solution mappings.
-        str
-            For CONSTRUCT or DESCRIBE queries, an RDF graph serialized in Turtle.
+        Any
+            - list of dict for SELECT
+            - bool for ASK
+            - str (RDF serialization) for CONSTRUCT/DESCRIBE
+            - None for UPDATE operations
         """
-        qstrip = sparql.lstrip()
-        head = qstrip.split(None, 1)[0].lower() if qstrip else ""
+        query_type = get_sparql_query_type(sparql)
+        chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="Oxigraph")
 
-        update_heads = {
-            "insert", "delete", "clear", "load", "create",
-            "drop", "with", "modify", "add", "move", "copy"
-        }
-        if head in update_heads:
+        #  UPDATE operations (INSERT, DELETE, CLEAR, DROP, LOAD, CREATE, etc.)
+        if query_type in {
+            "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
+            "MOVE", "COPY", "ADD", "MODIFY"
+        }:
             self.store.update(sparql)
             return None
 
-        return self.query(sparql)
+        result = self.store.query(sparql)
+
+        # ASK
+        if isinstance(result, QueryBoolean):
+            boolean_result = bool(result)
+            if export:
+                export_ask_result(boolean_result, output_format=chosen_format, filename=filename, backend_name="Oxigraph")
+            return boolean_result
+
+        # CONSTRUCT / DESCRIBE
+        if isinstance(result, QueryTriples):
+            rdf_text = result.serialize(format=RdfFormat.TURTLE).decode("utf-8")
+            if export:
+                export_rdf_result(rdf_text, output_format=chosen_format, filename=filename, backend_name="Oxigraph")
+            return rdf_text
+
+        try:
+            iter(result)
+        except TypeError:
+            return result
+
+        # SELECT
+        variable_names = [var.value for var in result.variables]
+        solutions: list[dict[str, str]] = []
+        for solution in result:
+            binding: dict[str, str] = {}
+            for var_name in variable_names:
+                try:
+                    term = solution[var_name]
+                except KeyError:
+                    continue
+                term_value = getattr(term, "value", None)
+                binding[var_name] = term_value if term_value is not None else str(term)
+            solutions.append(binding)
+
+        if export:
+            export_select_results(solutions, output_format=chosen_format, filename=filename, separator=separator, backend_name="Oxigraph")
+
+        return solutions
 
     def clear(self) -> None:
         """

--- a/triplestore/src/triplestore/backends/oxigraph.py
+++ b/triplestore/src/triplestore/backends/oxigraph.py
@@ -13,11 +13,18 @@ from triplestore.utils import (
     export_ask_result,
     export_rdf_result,
     export_select_results,
+    get_rdf_content_type,
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
     validate_rdf_term,
 )
+
+
+OXIGRAPH_RDF_FORMATS = {
+    "text/turtle": RdfFormat.TURTLE,
+    "application/n-triples": RdfFormat.N_TRIPLES,
+}
 
 
 class Oxigraph(TriplestoreBackend):
@@ -53,11 +60,16 @@ class Oxigraph(TriplestoreBackend):
 
     def load(self, filename: str) -> None:
         """
-        Load RDF triples from a Turtle (.ttl) file into the Oxigraph store.
+        Load RDF triples from a supported RDF file into the Oxigraph store.
+
+        Supported formats:
+        - .ttl: Turtle
+        - .nt: N-Triples
 
         Parameters:
         filename : str
-            Path to the Turtle (.ttl) file to be loaded.
+            Path to the RDF file to load (.ttl or .nt).
+
 
         Raises
         ------
@@ -68,12 +80,15 @@ class Oxigraph(TriplestoreBackend):
         if not path.exists():
             msg = f"[Oxigraph] File not found: {filename}"
             raise FileNotFoundError(msg)
+        
+        content_type = get_rdf_content_type(filename, backend_name="Oxigraph")
+        rdf_format = OXIGRAPH_RDF_FORMATS[content_type]
 
         with Path(filename).open("rb") as f:
             if self.graph_uri:
-                self.store.bulk_load(f, RdfFormat.TURTLE, to_graph=NamedNode(self.graph_uri))
+                self.store.bulk_load(f, rdf_format, to_graph=NamedNode(self.graph_uri))
             else:
-                self.store.bulk_load(f, RdfFormat.TURTLE, to_graph=DefaultGraph())
+                self.store.bulk_load(f, rdf_format, to_graph=DefaultGraph())
         self.store.optimize()
 
     def add(self, subject: Any, predicate: Any, obj: Any) -> None:

--- a/triplestore/src/triplestore/backends/qlever.py
+++ b/triplestore/src/triplestore/backends/qlever.py
@@ -10,7 +10,14 @@ from typing import Any
 import requests
 
 from triplestore.base import TriplestoreBackend
-from triplestore.utils import validate_config
+from triplestore.utils import (
+    export_ask_result,
+    export_rdf_result,
+    export_select_results,
+    get_sparql_query_type,
+    resolve_export_format,
+    validate_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -138,47 +145,86 @@ class QLever(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def query(self, sparql: str) -> list[dict[str, str]]:
+    def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
         """
         Execute a SPARQL SELECT query against QLever.
 
-        Parameters:
+        Parameters
+        ----------
         sparql : str
             The SPARQL query string.
+        export : bool, optional
+            If True, also save the query results to a local file.
+        output_format : str, optional
+            Export format for saved results. Supported: 'json', 'csv'.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
-        Returns:
-        list of dict
+        Returns
+        -------
+        list[dict[str, str]]
             A list of bindings from the query results.
 
         Raises
         ------
+        ValueError
+            If query() is called with a non-SELECT query or with an unsupported export format.
         RuntimeError
             If the query fails or the server returns an error response.
         """
+        query_type = get_sparql_query_type(sparql)
+
+        if query_type != "SELECT":
+            msg = (
+                f"[QLever] Unsupported query type '{query_type}' for query(). "
+                "Only SELECT queries are supported. "
+                "Use execute() for UPDATE queries or other query forms."
+            )
+            raise ValueError(msg)
+
+        if export:
+            chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="QLever")
+
         response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, timeout=None)
+
         if response.status_code != 200:
             msg = f"[QLever] SPARQL query failed: {response.status_code}\n{response.text}"
             raise RuntimeError(msg)
 
         data = response.json()
         bindings = data.get("results", {}).get("bindings", [])
-        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+        results = [{k: v["value"] for k, v in row.items()} for row in bindings]
 
-    def execute(self, sparql: str) -> Any:
+        if export:
+            export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="QLever")
+
+        return results
+
+    def execute(self, sparql: str, *, export: bool = False, output_format: str | None = None, filename: str | None = None, separator: str = ",") -> Any:
         """
         Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
 
-        Parameters:
+        Parameters
         ----------
         sparql : str
             The SPARQL query or update string.
+        export : bool, optional
+            If True, also save the query result to a local file.
+        output_format : str, optional
+            Export format for saved results. If omitted and export=True, a default format is chosen based on the query type.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
-        Returns:
-        ----------
+        Returns
+        -------
         Any
             - list of dict for SELECT
             - bool for ASK
-            - str (RDF serialization) for CONSTRUCT/DESCRIBE
+            - str (Turtle RDF) for CONSTRUCT/DESCRIBE
             - None for UPDATE operations
 
         Raises
@@ -186,40 +232,50 @@ class QLever(TriplestoreBackend):
         RuntimeError
             If the server responds with an error status.
         """
-        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
-
-        query_type = ""
-        for line in lines:
-            upper = line.upper()
-            if upper.startswith(("PREFIX ", "BASE ")):
-                continue
-            query_type = line.split(None, 1)[0].upper()
-            break
+        query_type = get_sparql_query_type(sparql)
+        chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="QLever")
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:
             response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[QLever] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
+
             data = response.json()
+
             if query_type == "ASK":
-                return bool(data.get("boolean", False))
+                result = bool(data.get("boolean", False))
+                if export:
+                    export_ask_result(result, output_format=chosen_format, filename=filename, backend_name="QLever")
+                return result
+
             bindings = data.get("results", {}).get("bindings", [])
-            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+            results = [{k: v["value"] for k, v in row.items()} for row in bindings]
+            if export:
+                export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="QLever")
+
+            return results
 
         # CONSTRUCT / DESCRIBE
         if query_type in {"CONSTRUCT", "DESCRIBE"}:
             response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": sparql}, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[QLever] SPARQL query failed: {response.status_code}\n{response.text}"
                 raise RuntimeError(msg)
-            return response.text
+
+            rdf_text = response.text
+            if export:
+                export_rdf_result(rdf_text, output_format=chosen_format, filename=filename, backend_name="QLever")
+
+            return rdf_text
 
         # UPDATE family
         if query_type in {
             "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
-            "MOVE", "COPY", "ADD", "MODIFY"
+            "MOVE", "COPY", "ADD", "MODIFY",
         }:
             self._run_update(sparql)
             return None

--- a/triplestore/src/triplestore/backends/qlever.py
+++ b/triplestore/src/triplestore/backends/qlever.py
@@ -17,6 +17,7 @@ from triplestore.utils import (
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
+    validate_rdf_term,
 )
 
 logger = logging.getLogger(__name__)
@@ -105,19 +106,23 @@ class QLever(TriplestoreBackend):
             msg = f"[QLever] Load failed with status: {response.status_code}\n{response.text}"
             raise RuntimeError(msg)
 
-    def add(self, s: str, p: str, o: str) -> None:
+    def add(self, s: Any, p: Any, o: Any) -> None:
         """
         Add a triple to the QLever store.
 
         Parameters:
-        s : str
-            Subject URI.
-        p : str
-            Predicate URI.
-        o : str
-            Object URI.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "QLever")
+        p_term = validate_rdf_term(p, "predicate", "QLever")
+        o_term = validate_rdf_term(o, "object", "QLever")
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri else
@@ -125,19 +130,39 @@ class QLever(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def delete(self, s: str, p: str, o: str) -> None:
+    def delete(self, s: Any, p: Any, o: Any) -> None:
         """
         Delete a triple from the QLever store.
 
         Parameters:
-        s : str
-            Subject URI.
-        p : str
-            Predicate URI.
-        o : str
-            Object URI.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
+
+        Raises
+        ------
+        ValueError
+            If a blank node is provided as the subject.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "QLever")
+        p_term = validate_rdf_term(p, "predicate", "QLever")
+        o_term = validate_rdf_term(o, "object", "QLever")
+
+        if isinstance(s, str) and s.startswith("_:"):
+            msg = (
+                "[QLever] Cannot delete triples using a blank node as subject.\n\n"
+                "Blank node identifiers (e.g. '_:b1') are local to a single SPARQL query "
+                "or update and do not represent stable, reusable identifiers.\n"
+                "Recommended alternatives:\n"
+                " - Use a persistent IRI instead of a blank node if you need to delete the triple later.\n"
+                " - Or delete using a pattern-based query (e.g. DELETE WHERE) that matches the triple.\n\n"
+            )
+            raise ValueError(msg)
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri else

--- a/triplestore/src/triplestore/backends/qlever.py
+++ b/triplestore/src/triplestore/backends/qlever.py
@@ -14,6 +14,7 @@ from triplestore.utils import (
     export_ask_result,
     export_rdf_result,
     export_select_results,
+    get_rdf_content_type,
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
@@ -75,11 +76,15 @@ class QLever(TriplestoreBackend):
 
     def load(self, filename: str) -> None:
         """
-        Load RDF triples from a Turtle (.ttl) file into QLever.
+        Load RDF triples from a supported RDF file into QLever.
+
+        Supported formats:
+        - .ttl: Turtle
+        - .nt: N-Triples
 
         Parameters:
         filename : str
-            Path to the Turtle (.ttl) file to be loaded.
+            Path to the RDF file to load (.ttl or .nt).
 
         Raises
         ------
@@ -92,6 +97,9 @@ class QLever(TriplestoreBackend):
             msg = f"[QLever] File not found: {filename}"
             raise FileNotFoundError(msg)
 
+        content_type = get_rdf_content_type(filename, backend_name="QLever")
+        headers = {"Content-Type": content_type}
+
         rdf_data = Path(filename).read_bytes()
         params = {}
 
@@ -101,7 +109,7 @@ class QLever(TriplestoreBackend):
         if self.access_token:
             params["access-token"] = self.access_token
 
-        response = requests.post(self.update_url, headers=self.headers_load, data=rdf_data, params=params, timeout=None)
+        response = requests.post(self.update_url, headers=headers, data=rdf_data, params=params, timeout=None)
         if response.status_code not in {200, 204, 201}:
             msg = f"[QLever] Load failed with status: {response.status_code}\n{response.text}"
             raise RuntimeError(msg)

--- a/triplestore/src/triplestore/backends/qlever.py
+++ b/triplestore/src/triplestore/backends/qlever.py
@@ -1,0 +1,441 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from triplestore.base import TriplestoreBackend
+from triplestore.utils import validate_config
+
+logger = logging.getLogger(__name__)
+
+
+class QLever(TriplestoreBackend):
+    """
+    A triplestore backend implementation for QLever using its HTTP REST API.
+    """
+
+    REQUIRED_KEYS = {"dataset", "working_directory"}
+    OPTIONAL_DEFAULTS = {
+        "base_url": "http://localhost:7019",
+        "graph": None,
+    }
+    ALIASES = {
+        "graph_uri": "graph",
+        "url": "base_url",
+        "endpoint": "base_url",
+    }
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """
+        Initialize the QLever backend with the given configuration.
+
+        Parameters:
+        config : dict
+            A configuration dictionary containing connection parameters:
+            - dataset : The name of the QLever dataset.
+            - working_directory : Directory where QLever configuration and index files are stored.
+            - base_url (optional): The base URL of the QLever HTTP endpoint.
+            - graph (optional): Named graph URI for scoped operations.
+        """
+
+        configuration = validate_config(config, required_keys=self.REQUIRED_KEYS, optional_defaults=self.OPTIONAL_DEFAULTS,
+                                        alias_map=self.ALIASES, backend_name="QLever")
+
+        super().__init__(configuration)
+        self.base_url = configuration["base_url"]
+        self.graph_uri = configuration["graph"]
+
+        self.query_url = self.base_url
+        self.update_url = self.base_url
+
+        self.headers_query = {"Accept": "application/sparql-results+json"}
+        self.headers_update = {"Content-Type": "application/sparql-update"}
+        self.headers_load = {"Content-Type": "text/turtle"}
+
+        self.dataset = configuration["dataset"]
+        self.working_directory = Path(configuration["working_directory"]).expanduser().resolve()
+        self.container_name = f"qlever.server.{self.dataset}"
+
+        self.start_server()
+        self.access_token = self._read_access_token()
+
+    def load(self, filename: str) -> None:
+        """
+        Load RDF triples from a Turtle (.ttl) file into QLever.
+
+        Parameters:
+        filename : str
+            Path to the Turtle (.ttl) file to be loaded.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the file does not exist.
+        RuntimeError
+            If the server responds with an error during data loading.
+        """
+        if not Path(filename).exists():
+            msg = f"[QLever] File not found: {filename}"
+            raise FileNotFoundError(msg)
+
+        rdf_data = Path(filename).read_bytes()
+        params = {}
+
+        if self.graph_uri:
+            params["graph"] = self.graph_uri
+
+        if self.access_token:
+            params["access-token"] = self.access_token
+
+        response = requests.post(self.update_url, headers=self.headers_load, data=rdf_data, params=params, timeout=None)
+        if response.status_code not in {200, 204, 201}:
+            msg = f"[QLever] Load failed with status: {response.status_code}\n{response.text}"
+            raise RuntimeError(msg)
+
+    def add(self, s: str, p: str, o: str) -> None:
+        """
+        Add a triple to the QLever store.
+
+        Parameters:
+        s : str
+            Subject URI.
+        p : str
+            Predicate URI.
+        o : str
+            Object URI.
+        """
+        triple = f"<{s}> <{p}> <{o}> ."
+        sparql = (
+            f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
+            if self.graph_uri else
+            f"INSERT DATA {{ {triple} }}"
+        )
+        self._run_update(sparql)
+
+    def delete(self, s: str, p: str, o: str) -> None:
+        """
+        Delete a triple from the QLever store.
+
+        Parameters:
+        s : str
+            Subject URI.
+        p : str
+            Predicate URI.
+        o : str
+            Object URI.
+        """
+        triple = f"<{s}> <{p}> <{o}> ."
+        sparql = (
+            f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
+            if self.graph_uri else
+            f"DELETE DATA {{ {triple} }}"
+        )
+        self._run_update(sparql)
+
+    def query(self, sparql: str) -> list[dict[str, str]]:
+        """
+        Execute a SPARQL SELECT query against QLever.
+
+        Parameters:
+        sparql : str
+            The SPARQL query string.
+
+        Returns:
+        list of dict
+            A list of bindings from the query results.
+
+        Raises
+        ------
+        RuntimeError
+            If the query fails or the server returns an error response.
+        """
+        response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, timeout=None)
+        if response.status_code != 200:
+            msg = f"[QLever] SPARQL query failed: {response.status_code}\n{response.text}"
+            raise RuntimeError(msg)
+
+        data = response.json()
+        bindings = data.get("results", {}).get("bindings", [])
+        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+
+    def execute(self, sparql: str) -> Any:
+        """
+        Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
+
+        Parameters:
+        ----------
+        sparql : str
+            The SPARQL query or update string.
+
+        Returns:
+        ----------
+        Any
+            - list of dict for SELECT
+            - bool for ASK
+            - str (RDF serialization) for CONSTRUCT/DESCRIBE
+            - None for UPDATE operations
+
+        Raises
+        ------
+        RuntimeError
+            If the server responds with an error status.
+        """
+        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
+
+        query_type = ""
+        for line in lines:
+            upper = line.upper()
+            if upper.startswith(("PREFIX ", "BASE ")):
+                continue
+            query_type = line.split(None, 1)[0].upper()
+            break
+
+        # SELECT / ASK
+        if query_type in {"SELECT", "ASK"}:
+            response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, timeout=None)
+            if response.status_code != 200:
+                msg = f"[QLever] Query failed {response.status_code}:\n{response.text}"
+                raise RuntimeError(msg)
+            data = response.json()
+            if query_type == "ASK":
+                return bool(data.get("boolean", False))
+            bindings = data.get("results", {}).get("bindings", [])
+            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+
+        # CONSTRUCT / DESCRIBE
+        if query_type in {"CONSTRUCT", "DESCRIBE"}:
+            response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": sparql}, timeout=None)
+            if response.status_code != 200:
+                msg = f"[QLever] SPARQL query failed: {response.status_code}\n{response.text}"
+                raise RuntimeError(msg)
+            return response.text
+
+        # UPDATE family
+        if query_type in {
+            "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
+            "MOVE", "COPY", "ADD", "MODIFY"
+        }:
+            self._run_update(sparql)
+            return None
+
+        msg = f"[QLever] Unsupported SPARQL keyword: {query_type}"
+        raise RuntimeError(msg)
+
+    def clear(self) -> None:
+        """
+        Clear all triples from the target graph or the default graph.
+        """
+        sparql = (
+            f"CLEAR GRAPH <{self.graph_uri}>"
+            if self.graph_uri else
+            "CLEAR DEFAULT"
+        )
+        self._run_update(sparql)
+
+    def _run_update(self, sparql: str) -> None:
+        """
+        Execute a SPARQL update request.
+
+        Parameters:
+        sparql : str
+            The SPARQL update string.
+
+        Raises
+        ------
+        RuntimeError
+            If the update operation fails with a non-success HTTP status code.
+        """
+        params = {}
+        if self.access_token:
+            params["access-token"] = self.access_token
+
+        response = requests.post(self.update_url, headers=self.headers_update, params=params, data=sparql, timeout=None)
+        if response.status_code not in {200, 204, 201}:
+            msg = f"[QLever] SPARQL update failed: {response.status_code}\n{response.text}"
+            raise RuntimeError(msg)
+
+    def start_server(self) -> None:
+        """
+        Start or initialize a QLever server for the configured dataset.
+
+        This method ensures that the QLever environment for the dataset is
+        properly prepared. If a container already exists, it will simply be
+        started. Otherwise the method performs the full initialization:
+
+        1. Create the working directory if it does not exist.
+        2. Generate the QLever configuration file (Qleverfile).
+        3. Download the dataset if it is not already present.
+        4. Build the QLever index.
+        5. Start the QLever server.
+
+        Raises
+        ------
+        ValueError
+        If the dataset name or working directory configuration is missing or invalid.
+        RuntimeError
+            If the QLever server fails to start or does not become ready.
+        """
+
+        if self.working_directory.exists() and not self.working_directory.is_dir():
+            msg = (
+                f"[QLever] Invalid working_directory: '{self.working_directory}' exists "
+                "but is not a directory. Please provide a valid directory path."
+            )
+            raise ValueError(msg)
+
+        self.working_directory.mkdir(parents=True, exist_ok=True)
+
+        if self._container_exists():
+            logger.info("QLever container '%s' already exists. Starting existing server...", self.container_name)
+
+            subprocess.run(["docker", "start", self.container_name], check=True)
+
+            self._wait_until_ready()
+            return
+
+        logger.info("Initializing QLever dataset '%s' in %s", self.dataset, self.working_directory)
+
+        qleverfile = self.working_directory / "Qleverfile"
+        if not qleverfile.exists():
+            subprocess.run(["qlever", "setup-config", self.dataset], cwd=self.working_directory, check=True)
+
+        data_file = self.working_directory / f"{self.dataset}.nt"
+        if not data_file.exists():
+            subprocess.run(["qlever", "get-data"], cwd=self.working_directory, check=True)
+
+        index_file = self.working_directory / f"{self.dataset}.index.pso"
+        if not index_file.exists():
+            subprocess.run(["qlever", "index"], cwd=self.working_directory, check=True)
+
+        subprocess.run(["qlever", "start"], cwd=self.working_directory, check=True)
+
+        self._wait_until_ready()
+
+    def stop_server(self) -> None:
+        """
+        Stop the QLever Docker container associated with this dataset.
+
+        Raises
+        ------
+        RuntimeError
+            If the Docker command fails or the container cannot be stopped.
+        """
+
+        logger.info("Stopping QLever container '%s'", self.container_name)
+
+        try:
+            subprocess.run(["docker", "stop", self.container_name], check=True)
+        except subprocess.CalledProcessError as exc:
+            msg = (
+                f"[QLever] Failed to stop container '{self.container_name}'. "
+                "Please check that Docker is running and the container exists."
+            )
+            raise RuntimeError(msg) from exc
+
+    def _read_access_token(self) -> str:
+        """
+        Read the QLever access token from the dataset Qleverfile.
+        The access token is required for authenticated update operations.
+
+        Returns
+        -------
+        str
+            The resolved access token for the current dataset.
+
+        Raises
+        ------
+        RuntimeError
+            If the Qleverfile does not exist or if the ACCESS_TOKEN entry cannot be found in the file.
+        """
+        qleverfile = self.working_directory / "Qleverfile"
+
+        if not qleverfile.exists():
+            msg = (
+                f"[QLever] Qleverfile not found in working directory: "
+                f"{self.working_directory}. "
+                "Make sure the dataset has been initialized with "
+                "'qlever setup-config'."
+            )
+            raise RuntimeError(msg)
+
+        with qleverfile.open(encoding="utf-8") as file_obj:
+            for raw_line in file_obj:
+                stripped_line = raw_line.strip()
+
+                if stripped_line.startswith("ACCESS_TOKEN"):
+                    _, value = stripped_line.split("=", 1)
+                    return value.strip().replace("${data:NAME}", self.dataset)
+
+        msg = ("[QLever] ACCESS_TOKEN not found in Qleverfile. "
+            "The dataset configuration may be incomplete."
+        )
+        raise RuntimeError(msg)
+
+    def _container_exists(self) -> bool:
+        """
+        Check whether the QLever Docker container already exists.
+
+        Returns
+        -------
+        bool
+            True if a container with the expected name exists, otherwise False.
+
+        Raises
+        ------
+        RuntimeError
+            If the Docker command cannot be executed.
+        """
+        try:
+            result = subprocess.run(
+                ["docker", "ps", "-a", "--format", "{{.Names}}"],
+                capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as exc:
+            msg = (
+                "[QLever] Failed to check existing Docker containers. "
+                "Please ensure Docker is installed and running."
+            )
+            raise RuntimeError(msg) from exc
+
+        return self.container_name in result.stdout.splitlines()
+
+    def _wait_until_ready(self, timeout: int = 30) -> None:
+        """
+        Wait until the QLever server becomes available.
+
+        Parameters
+        ----------
+        timeout : int, optional
+            Maximum number of seconds to wait for the server to become ready.
+            Default is 30 seconds.
+
+        Raises
+        ------
+        RuntimeError
+            If the server does not respond successfully within the timeout.
+        """
+
+        deadline = time.time() + timeout
+        last_error = None
+
+        while time.time() < deadline:
+            try:
+                response = requests.get(f"{self.base_url}/?cmd=stats", timeout=2)
+                if response.status_code == 200:
+                    return
+            except requests.RequestException as e:
+                last_error = e
+
+            time.sleep(1)
+
+        msg = (
+            f"[QLever] Server did not become ready at {self.base_url} "
+            f"within {timeout} seconds. Please check that the server started "
+            "correctly and that the endpoint is reachable."
+        )
+        raise RuntimeError(msg) from last_error

--- a/triplestore/src/triplestore/backends/rdf4j.py
+++ b/triplestore/src/triplestore/backends/rdf4j.py
@@ -8,7 +8,14 @@ from typing import Any
 import requests
 
 from triplestore.base import TriplestoreBackend
-from triplestore.utils import validate_config
+from triplestore.utils import (
+    export_ask_result,
+    export_rdf_result,
+    export_select_results,
+    get_sparql_query_type,
+    resolve_export_format,
+    validate_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +148,7 @@ class RDF4J(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def query(self, sparql: str) -> list[dict[str, str]]:
+    def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
         """
         Execute a SPARQL SELECT query against the RDF4J repository.
 
@@ -149,6 +156,14 @@ class RDF4J(TriplestoreBackend):
         ----------
         sparql : str
             The SPARQL query string.
+        export : bool, optional
+            If True, also save the query results to a local file.
+        output_format : str, optional
+            Export format for saved results. Supported: 'json', 'csv'.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
         Returns
         -------
@@ -157,9 +172,24 @@ class RDF4J(TriplestoreBackend):
 
         Raises
         ------
+        ValueError
+            If query() is called with a non-SELECT query or with an unsupported export format.
         RuntimeError
             If the query fails or the server returns an error response.
         """
+        query_type = get_sparql_query_type(sparql)
+
+        if query_type != "SELECT":
+            msg = (
+                f"[RDF4J] Unsupported query type '{query_type}' for query(). "
+                "Only SELECT queries are supported. "
+                "Use execute() for UPDATE queries or other query forms."
+            )
+            raise ValueError(msg)
+
+        if export:
+            chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="RDF4J")
+
         response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
 
         if response.status_code != 200:
@@ -168,9 +198,14 @@ class RDF4J(TriplestoreBackend):
 
         data = response.json()
         bindings = data.get("results", {}).get("bindings", [])
-        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+        results = [{k: v["value"] for k, v in row.items()} for row in bindings]
 
-    def execute(self, sparql: str) -> Any:
+        if export:
+            export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="RDF4J")
+
+        return results
+
+    def execute(self, sparql: str, *, export: bool = False, output_format: str | None = None, filename: str | None = None, separator: str = ",") -> Any:
         """
         Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
 
@@ -178,6 +213,14 @@ class RDF4J(TriplestoreBackend):
         ----------
         sparql : str
             The SPARQL query or update string.
+        export : bool, optional
+            If True, also save the query result to a local file.
+        output_format : str, optional
+            Export format for saved results. If omitted and export=True, a default format is chosen based on the query type.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
         Returns
         -------
@@ -192,37 +235,48 @@ class RDF4J(TriplestoreBackend):
         RuntimeError
             If the server responds with an error status.
         """
-        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
-
-        query_type = ""
-        for line in lines:
-            upper = line.upper()
-            if upper.startswith(("PREFIX ", "BASE ")):
-                continue
-            query_type = line.split(None, 1)[0].upper()
-            break
+        query_type = get_sparql_query_type(sparql)
+        chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="RDF4J")
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:
             response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[RDF4J] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
+
             data = response.json()
+
             if query_type == "ASK":
-                return bool(data.get("boolean", False))
+                result = bool(data.get("boolean", False))
+                if export:
+                    export_ask_result(result, output_format=chosen_format, filename=filename, backend_name="RDF4J")
+                return result
+
             bindings = data.get("results", {}).get("bindings", [])
-            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+            results = [{k: v["value"] for k, v in row.items()} for row in bindings]
+            if export:
+                export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="RDF4J")
+
+            return results
 
         # CONSTRUCT / DESCRIBE
         if query_type in {"CONSTRUCT", "DESCRIBE"}:
             response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": sparql}, auth=self.auth, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[RDF4J] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
-            return response.text
 
-        #  UPDATE operations (INSERT, DELETE, CLEAR, DROP, LOAD, CREATE, etc.)
+            rdf_text = response.text
+
+            if export:
+                export_rdf_result(rdf_text, output_format=chosen_format, filename=filename, backend_name="RDF4J")
+
+            return rdf_text
+
+        # UPDATE operations
         if query_type in {
             "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
             "MOVE", "COPY", "ADD", "MODIFY"

--- a/triplestore/src/triplestore/backends/rdf4j.py
+++ b/triplestore/src/triplestore/backends/rdf4j.py
@@ -1,0 +1,414 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from triplestore.base import TriplestoreBackend
+from triplestore.utils import validate_config
+
+logger = logging.getLogger(__name__)
+
+
+class RDF4J(TriplestoreBackend):
+    """
+    A triplestore backend implementation for Eclipse RDF4J Server using its HTTP REST API.
+    """
+
+    REQUIRED_KEYS = {"name"}
+    OPTIONAL_DEFAULTS = {
+        "base_url": "http://localhost:8080/rdf4j-server",
+        "graph": None,
+        "auth": None,
+        "store_type": "native",
+    }
+    ALIASES = {
+        "graph_uri": "graph",
+        "repository": "name",
+    }
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """
+        Initialize the RDF4J backend with the given configuration.
+
+        Parameters
+        ----------
+        config : dict
+            A configuration dictionary containing connection parameters:
+            - base_url (optional): The base URL of the RDF4J Server.
+            - repository : The name of the target repository.
+            - auth (optional): Tuple (username, password) for HTTP Basic Auth.
+            - graph (optional): Named graph URI for scoped operations.
+
+        Raises
+        ------
+        ValueError
+            If the required configuration is missing.
+        RuntimeError
+            If the repository does not exist or the server is unreachable.
+        """
+        configuration = validate_config(config, required_keys=self.REQUIRED_KEYS, optional_defaults=self.OPTIONAL_DEFAULTS,
+                                        alias_map=self.ALIASES, backend_name="RDF4J")
+
+        super().__init__(configuration)
+        self.base_url = configuration["base_url"].rstrip("/")
+        self.repository = configuration["name"]
+        self.auth = configuration["auth"]
+        self.graph_uri = configuration["graph"]
+        self.store_type = str(configuration["store_type"]).strip().lower()
+
+        self.query_url = f"{self.base_url}/repositories/{self.repository}"
+        self.update_url = f"{self.query_url}/statements"
+
+        self.headers_query = {"Accept": "application/sparql-results+json"}
+        self.headers_update = {"Content-Type": "application/sparql-update"}
+        self.headers_load = {"Content-Type": "text/turtle"}
+
+        self._ensure_repository_exists()
+
+    def load(self, filename: str) -> None:
+        """
+        Load RDF triples from a Turtle (.ttl) file into the RDF4J repository.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the Turtle (.ttl) file to be loaded.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the file does not exist.
+        RuntimeError
+            If the server returns an error status during data loading.
+        """
+        if not Path(filename).exists():
+            msg = f"[RDF4J] File not found: {filename}"
+            raise FileNotFoundError(msg)
+
+        rdf_data = Path(filename).read_bytes()
+        params = {}
+        if self.graph_uri:
+            params["context"] = f"<{self.graph_uri}>"
+        response = requests.post(self.update_url, headers=self.headers_load, params=params, data=rdf_data, auth=self.auth, timeout=None)
+
+        if response.status_code not in {200, 204, 201}:
+            msg = f"[RDF4J] Load failed with status {response.status_code}:\n{response.text}"
+            raise RuntimeError(msg)
+
+    def add(self, s: str, p: str, o: str) -> None:
+        """
+        Add a triple to the RDF4J store.
+
+        Parameters
+        ----------
+        s : str
+            The subject URI of the triple.
+        p : str
+            The predicate URI of the triple.
+        o : str
+            The object URI of the triple.
+        """
+        triple = f"<{s}> <{p}> <{o}> ."
+        sparql = (
+            f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
+            if self.graph_uri
+            else f"INSERT DATA {{ {triple} }}"
+        )
+        self._run_update(sparql)
+
+    def delete(self, s: str, p: str, o: str) -> None:
+        """
+        Delete a triple from the RDF4J store.
+
+        Parameters
+        ----------
+        s : str
+            The subject URI of the triple to remove.
+        p : str
+            The predicate URI of the triple to remove.
+        o : str
+            The object URI of the triple to remove.
+        """
+        triple = f"<{s}> <{p}> <{o}> ."
+        sparql = (
+            f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
+            if self.graph_uri
+            else f"DELETE DATA {{ {triple} }}"
+        )
+        self._run_update(sparql)
+
+    def query(self, sparql: str) -> list[dict[str, str]]:
+        """
+        Execute a SPARQL SELECT query against the RDF4J repository.
+
+        Parameters
+        ----------
+        sparql : str
+            The SPARQL query string.
+
+        Returns
+        -------
+        list[dict[str, str]]
+            The list of query result bindings.
+
+        Raises
+        ------
+        RuntimeError
+            If the query fails or the server returns an error response.
+        """
+        response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
+
+        if response.status_code != 200:
+            msg = f"[RDF4J] SPARQL query failed: {response.status_code}\n{response.text}"
+            raise RuntimeError(msg)
+
+        data = response.json()
+        bindings = data.get("results", {}).get("bindings", [])
+        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+
+    def execute(self, sparql: str) -> Any:
+        """
+        Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
+
+        Parameters
+        ----------
+        sparql : str
+            The SPARQL query or update string.
+
+        Returns
+        -------
+        Any
+            - list of dict for SELECT
+            - bool for ASK
+            - str (Turtle RDF) for CONSTRUCT/DESCRIBE
+            - None for UPDATE operations
+
+        Raises
+        ------
+        RuntimeError
+            If the server responds with an error status.
+        """
+        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
+
+        query_type = ""
+        for line in lines:
+            upper = line.upper()
+            if upper.startswith(("PREFIX ", "BASE ")):
+                continue
+            query_type = line.split(None, 1)[0].upper()
+            break
+
+        # SELECT / ASK
+        if query_type in {"SELECT", "ASK"}:
+            response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
+            if response.status_code != 200:
+                msg = f"[RDF4J] Query failed {response.status_code}:\n{response.text}"
+                raise RuntimeError(msg)
+            data = response.json()
+            if query_type == "ASK":
+                return bool(data.get("boolean", False))
+            bindings = data.get("results", {}).get("bindings", [])
+            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+
+        # CONSTRUCT / DESCRIBE
+        if query_type in {"CONSTRUCT", "DESCRIBE"}:
+            response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": sparql}, auth=self.auth, timeout=None)
+            if response.status_code != 200:
+                msg = f"[RDF4J] Query failed {response.status_code}:\n{response.text}"
+                raise RuntimeError(msg)
+            return response.text
+
+        #  UPDATE operations (INSERT, DELETE, CLEAR, DROP, LOAD, CREATE, etc.)
+        if query_type in {
+            "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
+            "MOVE", "COPY", "ADD", "MODIFY"
+        }:
+            self._run_update(sparql)
+            return None
+
+        msg = f"[RDF4J] Unsupported SPARQL keyword: {query_type}"
+        raise RuntimeError(msg)
+
+    def clear(self) -> None:
+        """
+        Remove all data from the RDF4J repository (default and named graphs).
+        """
+        sparql = f"CLEAR GRAPH <{self.graph_uri}>" if self.graph_uri else "CLEAR DEFAULT"
+        self._run_update(sparql)
+
+    def _run_update(self, sparql: str) -> None:
+        """
+        Execute a SPARQL update operation.
+
+        Parameters
+        ----------
+        sparql : str
+            The SPARQL update string to be sent to the server.
+
+        Raises
+        ------
+        RuntimeError
+            If the update operation fails with a non-success status code.
+        """
+        response = requests.post(self.update_url, headers=self.headers_update, data=sparql, auth=self.auth, timeout=None)
+
+        if response.status_code not in {200, 204, 201}:
+            msg = f"[RDF4J] SPARQL update failed: {response.status_code}\n{response.text}"
+            raise RuntimeError(msg)
+
+    def _build_repository_config(self) -> str:
+        """
+        Build a Turtle (TTL) configuration for creating an RDF4J repository.
+        The configuration depends on the selected `store_type`:
+        - memory : in-memory store (non-persistent)
+        - native : disk-based store (persistent)
+
+        Returns
+        -------
+        str
+            A Turtle-formatted configuration string suitable for the RDF4J repository creation endpoint.
+
+        Raises
+        ------
+        ValueError
+           If an unsupported store_type is provided.
+        """
+        if self.store_type == "memory":
+            return f"""
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+            @prefix rep: <http://www.openrdf.org/config/repository#>.
+            @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+            @prefix sail: <http://www.openrdf.org/config/sail#>.
+            @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+
+            [] a rep:Repository ;
+            rep:repositoryID "{self.repository}" ;
+            rdfs:label "{self.repository}" ;
+            rep:repositoryImpl [
+                rep:repositoryType "openrdf:SailRepository" ;
+                sr:sailImpl [
+                    sail:sailType "openrdf:MemoryStore"
+                ]
+            ] .
+            """.strip()
+
+        if self.store_type == "native":
+            return f"""
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+            @prefix rep: <http://www.openrdf.org/config/repository#>.
+            @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+            @prefix sail: <http://www.openrdf.org/config/sail#>.
+            @prefix ns: <http://www.openrdf.org/config/sail/native#>.
+
+            [] a rep:Repository ;
+            rep:repositoryID "{self.repository}" ;
+            rdfs:label "{self.repository}" ;
+            rep:repositoryImpl [
+                rep:repositoryType "openrdf:SailRepository" ;
+                sr:sailImpl [
+                    sail:sailType "openrdf:NativeStore" ;
+                    ns:tripleIndexes "spoc,posc" ;
+                    ns:forceSync true
+                ]
+            ] .
+            """.strip()
+
+        msg = (
+            f"[RDF4J] Unsupported store_type '{self.store_type}'. "
+            f"Supported values are: 'memory', 'native'."
+        )
+        raise ValueError(msg)
+
+    def _repository_exists(self) -> bool:
+        """
+        Check whether the configured repository already exists in RDF4J Server.
+
+        Returns
+        -------
+        bool
+            True if the repository exists, False otherwise.
+
+        Raises
+        ------
+        RuntimeError
+            If the server cannot be reached or returns an unexpected error.
+        """
+        list_url = f"{self.base_url}/repositories"
+        headers = {"Accept": "application/sparql-results+json, application/json"}
+
+        try:
+            response = requests.get(list_url, headers=headers, timeout=30, auth=self.auth)
+        except requests.RequestException as e:
+            msg = f"[RDF4J] Could not connect to RDF4J at {list_url}: {e}"
+            raise RuntimeError(msg) from e
+
+        if response.status_code in {401, 403}:
+            msg = (
+                f"[RDF4J] Access denied while listing repositories "
+                f"(HTTP {response.status_code})."
+            )
+            raise RuntimeError(msg)
+
+        if response.status_code != 200:
+            msg = (
+                f"[RDF4J] Failed to retrieve repository list: "
+                f"{response.status_code} {response.text}"
+            )
+            raise RuntimeError(msg)
+
+        content_type = response.headers.get("Content-Type", "").lower()
+
+        if "json" in content_type:
+            try:
+                data = response.json()
+            except ValueError as e:
+                msg = "[RDF4J] Failed to parse repository list response as JSON."
+                raise RuntimeError(msg) from e
+
+            bindings = data.get("results", {}).get("bindings", [])
+            repo_ids = {row.get("id", {}).get("value") for row in bindings if row.get("id", {}).get("value")}
+            return self.repository in repo_ids
+
+        text = response.text
+        markers = (
+            f">{self.repository}<",
+            f'"{self.repository}"',
+            f"'{self.repository}'",
+            f"/repositories/{self.repository}",
+        )
+        return any(marker in text for marker in markers)
+
+    def _ensure_repository_exists(self) -> None:
+        """
+        Ensure that the configured repository exists in the RDF4J server.
+        If the repository does not exist, attempt to create it using the
+        RDF4J REST API and a generated Turtle configuration.
+
+        Raises
+        ------
+        RuntimeError
+            If the server cannot be reached or if repository creation fails.
+        """
+        if self._repository_exists():
+            return
+
+        config_ttl = self._build_repository_config()
+        create_url = f"{self.base_url}/repositories/{self.repository}"
+        create_headers = {"Content-Type": "text/turtle"}
+
+        try:
+            create_response = requests.put(create_url, headers=create_headers, data=config_ttl.encode("utf-8"), auth=self.auth, timeout=300)
+        except requests.RequestException as e:
+            msg = f"[RDF4J] Failed to create repository '{self.repository}': {e}"
+            raise RuntimeError(msg) from e
+
+        if create_response.status_code not in {200, 201, 204}:
+            msg = (
+                f"[RDF4J] Repository creation failed for '{self.repository}': "
+                f"{create_response.status_code}\n{create_response.text}"
+            )
+            raise RuntimeError(msg)

--- a/triplestore/src/triplestore/backends/rdf4j.py
+++ b/triplestore/src/triplestore/backends/rdf4j.py
@@ -15,6 +15,7 @@ from triplestore.utils import (
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
+    validate_rdf_term,
 )
 
 logger = logging.getLogger(__name__)
@@ -106,20 +107,24 @@ class RDF4J(TriplestoreBackend):
             msg = f"[RDF4J] Load failed with status {response.status_code}:\n{response.text}"
             raise RuntimeError(msg)
 
-    def add(self, s: str, p: str, o: str) -> None:
+    def add(self, s: Any, p: Any, o: Any) -> None:
         """
         Add a triple to the RDF4J store.
 
         Parameters
         ----------
-        s : str
-            The subject URI of the triple.
-        p : str
-            The predicate URI of the triple.
-        o : str
-            The object URI of the triple.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "RDF4J")
+        p_term = validate_rdf_term(p, "predicate", "RDF4J")
+        o_term = validate_rdf_term(o, "object", "RDF4J")
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri
@@ -127,20 +132,40 @@ class RDF4J(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def delete(self, s: str, p: str, o: str) -> None:
+    def delete(self, s: Any, p: Any, o: Any) -> None:
         """
         Delete a triple from the RDF4J store.
 
         Parameters
         ----------
-        s : str
-            The subject URI of the triple to remove.
-        p : str
-            The predicate URI of the triple to remove.
-        o : str
-            The object URI of the triple to remove.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
+
+        Raises
+        ------
+        ValueError
+            If a blank node is provided as the subject.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "RDF4J")
+        p_term = validate_rdf_term(p, "predicate", "RDF4J")
+        o_term = validate_rdf_term(o, "object", "RDF4J")
+
+        if isinstance(s, str) and s.startswith("_:"):
+            msg = (
+                "[RDF4J] Cannot delete triples using a blank node as subject.\n\n"
+                "Blank node identifiers (e.g. '_:b1') are local to a single SPARQL query "
+                "or update and do not represent stable, reusable identifiers.\n"
+                "Recommended alternatives:\n"
+                " - Use a persistent IRI instead of a blank node if you need to delete the triple later.\n"
+                " - Or delete using a pattern-based query (e.g. DELETE WHERE) that matches the triple.\n\n"
+            )
+            raise ValueError(msg)
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri

--- a/triplestore/src/triplestore/backends/rdf4j.py
+++ b/triplestore/src/triplestore/backends/rdf4j.py
@@ -12,6 +12,7 @@ from triplestore.utils import (
     export_ask_result,
     export_rdf_result,
     export_select_results,
+    get_rdf_content_type,
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
@@ -79,12 +80,16 @@ class RDF4J(TriplestoreBackend):
 
     def load(self, filename: str) -> None:
         """
-        Load RDF triples from a Turtle (.ttl) file into the RDF4J repository.
+        Load RDF triples from a supported RDF file into the RDF4J repository.
+
+        Supported formats:
+        - .ttl: Turtle
+        - .nt: N-Triples
 
         Parameters
         ----------
         filename : str
-            Path to the Turtle (.ttl) file to be loaded.
+            Path to the RDF file to load (.ttl or .nt).
 
         Raises
         ------
@@ -96,12 +101,15 @@ class RDF4J(TriplestoreBackend):
         if not Path(filename).exists():
             msg = f"[RDF4J] File not found: {filename}"
             raise FileNotFoundError(msg)
+        
+        content_type = get_rdf_content_type(filename, backend_name="RDF4J")
+        headers = {"Content-Type": content_type}
 
         rdf_data = Path(filename).read_bytes()
         params = {}
         if self.graph_uri:
             params["context"] = f"<{self.graph_uri}>"
-        response = requests.post(self.update_url, headers=self.headers_load, params=params, data=rdf_data, auth=self.auth, timeout=None)
+        response = requests.post(self.update_url, headers=headers, params=params, data=rdf_data, auth=self.auth, timeout=None)
 
         if response.status_code not in {200, 204, 201}:
             msg = f"[RDF4J] Load failed with status {response.status_code}:\n{response.text}"

--- a/triplestore/src/triplestore/backends/virtuoso.py
+++ b/triplestore/src/triplestore/backends/virtuoso.py
@@ -11,7 +11,14 @@ import requests
 from requests.auth import HTTPDigestAuth
 
 from triplestore.base import TriplestoreBackend
-from triplestore.utils import validate_config
+from triplestore.utils import (
+    export_ask_result,
+    export_rdf_result,
+    export_select_results,
+    get_sparql_query_type,
+    resolve_export_format,
+    validate_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -175,23 +182,48 @@ class Virtuoso(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def query(self, sparql: str) -> list[dict[str, str]]:
+    def query(self, sparql: str, *, export: bool = False, output_format: str = "json", filename: str | None = None, separator: str = ",") -> list[dict[str, str]]:
         """
-        Execute a SPARQL query against the Virtuoso endpoint.
+        Execute a SPARQL SELECT query against the Virtuoso endpoint.
 
-        Parameters:
+        Parameters
+        ----------
         sparql : str
             The SPARQL query string.
+        export : bool, optional
+            If True, also save the query results to a local file.
+        output_format : str, optional
+            Export format for saved results. Supported: 'json', 'csv'.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
-        Returns:
-        list of dict
+        Returns
+        -------
+        list[dict[str, str]]
             The list of query result bindings.
 
         Raises
         ------
+        ValueError
+            If query() is called with a non-SELECT query or with an unsupported export format.
         RuntimeError
             If the query fails or the server returns an error response.
         """
+        query_type = get_sparql_query_type(sparql)
+
+        if query_type != "SELECT":
+            msg = (
+                f"[Virtuoso] Unsupported query type '{query_type}' for query(). "
+                "Only SELECT queries are supported. "
+                "Use execute() for UPDATE queries or other query forms."
+            )
+            raise ValueError(msg)
+
+        if export:
+            chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="Virtuoso")
+
         response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
 
         if response.status_code != 200:
@@ -200,9 +232,14 @@ class Virtuoso(TriplestoreBackend):
 
         data = response.json()
         bindings = data.get("results", {}).get("bindings", [])
-        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+        results = [{k: v["value"] for k, v in row.items()} for row in bindings]
 
-    def execute(self, sparql: str) -> Any:
+        if export:
+            export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="Virtuoso")
+
+        return results
+
+    def execute(self, sparql: str, *, export: bool = False, output_format: str | None = None, filename: str | None = None, separator: str = ",") -> Any:
         """
         Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
 
@@ -210,6 +247,14 @@ class Virtuoso(TriplestoreBackend):
         ----------
         sparql : str
             The SPARQL query or update string.
+        export : bool, optional
+            If True, also save the query result to a local file.
+        output_format : str, optional
+            Export format for saved results. If omitted and export=True, a default format is chosen based on the query type.
+        filename : str, optional
+            Output filename for exported results. The file extension is determined automatically from the requested export format.
+        separator : str, optional
+            Column separator to use when exporting CSV files. Defaults to ",".
 
         Returns
         -------
@@ -224,37 +269,47 @@ class Virtuoso(TriplestoreBackend):
         RuntimeError
             If the server responds with an error status.
         """
-        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
-
-        query_type = ""
-        for line in lines:
-            upper = line.upper()
-            if upper.startswith(("PREFIX ", "BASE ")):
-                continue
-            query_type = line.split(None, 1)[0].upper()
-            break
+        query_type = get_sparql_query_type(sparql)
+        chosen_format = resolve_export_format(query_type, export=export, output_format=output_format, backend_name="Virtuoso")
 
         # SELECT / ASK
         if query_type in {"SELECT", "ASK"}:
             response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[Virtuoso] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
+
             data = response.json()
+
             if query_type == "ASK":
-                return bool(data.get("boolean", False))
+                result = bool(data.get("boolean", False))
+                if export:
+                    export_ask_result(result, output_format=chosen_format, filename=filename, backend_name="Virtuoso")
+                return result
+
             bindings = data.get("results", {}).get("bindings", [])
-            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+            results = [{k: v["value"] for k, v in row.items()} for row in bindings]
+            if export:
+                export_select_results(results, output_format=chosen_format, filename=filename, separator=separator, backend_name="Virtuoso")
+
+            return results
 
         # CONSTRUCT / DESCRIBE
         if query_type in {"CONSTRUCT", "DESCRIBE"}:
             response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": sparql}, auth=self.auth, timeout=None)
+
             if response.status_code != 200:
                 msg = f"[Virtuoso] Query failed {response.status_code}:\n{response.text}"
                 raise RuntimeError(msg)
-            return response.text
 
-        # UPDATE operations (INSERT, DELETE, CLEAR, DROP, LOAD, CREATE, etc.)
+            rdf_text = response.text
+            if export:
+                export_rdf_result(rdf_text, output_format=chosen_format, filename=filename, backend_name="Virtuoso")
+
+            return rdf_text
+
+        # UPDATE operations
         if query_type in {
             "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
             "MOVE", "COPY", "ADD", "MODIFY",

--- a/triplestore/src/triplestore/backends/virtuoso.py
+++ b/triplestore/src/triplestore/backends/virtuoso.py
@@ -1,0 +1,360 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+from requests.auth import HTTPDigestAuth
+
+from triplestore.base import TriplestoreBackend
+from triplestore.utils import validate_config
+
+logger = logging.getLogger(__name__)
+
+
+class Virtuoso(TriplestoreBackend):
+    """
+    A triplestore backend implementation for OpenLink Virtuoso using its HTTP SPARQL API.
+    """
+
+    REQUIRED_KEYS = {}
+    OPTIONAL_DEFAULTS = {
+        "base_url": "http://localhost:8890",
+        "graph": None,
+        "auth": None,
+        "name": "test"
+    }
+    ALIASES = {
+        "graph_uri": "graph",
+        "repository": "name",
+    }
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """
+        Initialize the Virtuoso backend with the given configuration.
+
+        Parameters:
+        ----------
+        config : dict
+            Connection settings for the Virtuoso instance. Supported keys:
+            - base_url : str, optional
+                Base URL of the Virtuoso server (default: http://localhost:8890).
+            - name : str, optional
+                Logical repository name used as a fallback graph identifier.
+            - auth : tuple[str, str], optional
+                Credentials in the form (username, password).
+            - graph : str, optional
+                Named graph URI for scoping SPARQL operations.
+
+        Raises
+        ------
+        ValueError
+            If the provided `auth` value is invalid or if no credentials are
+            available via configuration or environment variables.
+        RuntimeError
+            If the Virtuoso SPARQL endpoint is unreachable.
+        """
+        configuration = validate_config(config, required_keys=self.REQUIRED_KEYS, optional_defaults=self.OPTIONAL_DEFAULTS,
+                                        alias_map=self.ALIASES, backend_name="Virtuoso")
+
+        super().__init__(configuration)
+        self.base_url = self._normalize_base_url(configuration["base_url"])
+        self.repository = configuration["name"]
+        self.graph_uri = configuration["graph"] or self._default_graph_uri(self.repository)
+
+        auth_cfg = configuration["auth"]
+        username: str | None = None
+        password: str | None = None
+
+        if auth_cfg is not None:
+            try:
+                username, password = auth_cfg
+            except Exception as e:
+                msg = (
+                    "[Virtuoso] Invalid value for 'auth' in config. "
+                    "Expected a tuple of the form (username, password).\n"
+                    'Example: auth=("dba", "dba")'
+                )
+                raise ValueError(msg) from e
+
+        if not username or not password:
+            env_user = os.getenv("VIRTUOSO_USERNAME")
+            env_pass = os.getenv("VIRTUOSO_PASSWORD")
+            if env_user and env_pass:
+                username, password = env_user, env_pass
+
+        if not username or not password:
+            msg = (
+                "[Virtuoso] No credentials found. "
+                "Please provide login details either:\n"
+                "  • in the config: auth=(username, password)\n"
+                "  • or via environment variables: VIRTUOSO_USERNAME / VIRTUOSO_PASSWORD\n"
+                "Without valid credentials, the connection to Virtuoso cannot be established."
+            )
+            raise ValueError(msg)
+        self.auth = HTTPDigestAuth(username, password)
+
+        self.query_url = f"{self.base_url}/sparql"
+        self.update_url = f"{self.base_url}/sparql-auth"
+        self.graph_store_url = f"{self.base_url}/sparql-graph-crud-auth"
+
+        self.headers_query = {"Accept": "application/sparql-results+json"}
+        self.headers_update = {"Content-Type": "application/sparql-update"}
+        self.headers_load = {"Content-Type": "text/turtle"}
+
+        self._ensure_endpoint_exists()
+
+    def load(self, filename: str) -> None:
+        """
+        Load RDF triples from a Turtle (.ttl) file into a Virtuoso named graph.
+
+        Parameters:
+        filename : str
+            Path to the Turtle (.ttl) file to be loaded.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the file does not exist.
+        RuntimeError
+            If the server returns an error status during data loading.
+        """
+        if not Path(filename).exists():
+            msg = f"[Virtuoso] File not found: {filename}"
+            raise FileNotFoundError(msg)
+
+        rdf_data = Path(filename).read_bytes()
+        params = {"graph-uri": self.graph_uri} if self.graph_uri else {}
+        response = requests.post(self.graph_store_url, headers=self.headers_load, params=params, data=rdf_data, auth=self.auth, timeout=None)
+
+        if response.status_code not in {200, 201, 204}:
+            msg = f"[Virtuoso] Load failed with status {response.status_code}:\n{response.text}"
+            raise RuntimeError(msg)
+
+    def add(self, s: str, p: str, o: str) -> None:
+        """
+        Add a triple to the Virtuoso store.
+
+        Parameters:
+        s : str
+            The subject URI of the triple.
+        p : str
+            The predicate URI of the triple.
+        o : str
+            The object URI of the triple.
+        """
+        triple = f"<{s}> <{p}> <{o}> ."
+        sparql = (
+            f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
+            if self.graph_uri
+            else f"INSERT DATA {{ {triple} }}"
+        )
+        self._run_update(sparql)
+
+    def delete(self, s: str, p: str, o: str) -> None:
+        """
+        Delete a triple from the Virtuoso store.
+
+        Parameters:
+        s : str
+            The subject URI of the triple to remove.
+        p : str
+            The predicate URI of the triple to remove.
+        o : str
+            The object URI of the triple to remove.
+        """
+        triple = f"<{s}> <{p}> <{o}> ."
+        sparql = (
+            f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
+            if self.graph_uri
+            else f"DELETE DATA {{ {triple} }}"
+        )
+        self._run_update(sparql)
+
+    def query(self, sparql: str) -> list[dict[str, str]]:
+        """
+        Execute a SPARQL query against the Virtuoso endpoint.
+
+        Parameters:
+        sparql : str
+            The SPARQL query string.
+
+        Returns:
+        list of dict
+            The list of query result bindings.
+
+        Raises
+        ------
+        RuntimeError
+            If the query fails or the server returns an error response.
+        """
+        response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
+
+        if response.status_code != 200:
+            msg = f"[Virtuoso] SPARQL query failed: {response.status_code}\n{response.text}"
+            raise RuntimeError(msg)
+
+        data = response.json()
+        bindings = data.get("results", {}).get("bindings", [])
+        return [{k: v["value"] for k, v in row.items()} for row in bindings]
+
+    def execute(self, sparql: str) -> Any:
+        """
+        Execute any SPARQL query (SELECT, ASK, CONSTRUCT, DESCRIBE, UPDATE).
+
+        Parameters
+        ----------
+        sparql : str
+            The SPARQL query or update string.
+
+        Returns
+        -------
+        Any
+            - list of dict for SELECT
+            - bool for ASK
+            - str (Turtle RDF) for CONSTRUCT/DESCRIBE
+            - None for UPDATE operations
+
+        Raises
+        ------
+        RuntimeError
+            If the server responds with an error status.
+        """
+        lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
+
+        query_type = ""
+        for line in lines:
+            upper = line.upper()
+            if upper.startswith(("PREFIX ", "BASE ")):
+                continue
+            query_type = line.split(None, 1)[0].upper()
+            break
+
+        # SELECT / ASK
+        if query_type in {"SELECT", "ASK"}:
+            response = requests.post(self.query_url, headers=self.headers_query, data={"query": sparql}, auth=self.auth, timeout=None)
+            if response.status_code != 200:
+                msg = f"[Virtuoso] Query failed {response.status_code}:\n{response.text}"
+                raise RuntimeError(msg)
+            data = response.json()
+            if query_type == "ASK":
+                return bool(data.get("boolean", False))
+            bindings = data.get("results", {}).get("bindings", [])
+            return [{k: v["value"] for k, v in row.items()} for row in bindings]
+
+        # CONSTRUCT / DESCRIBE
+        if query_type in {"CONSTRUCT", "DESCRIBE"}:
+            response = requests.post(self.query_url, headers={"Accept": "text/turtle"}, data={"query": sparql}, auth=self.auth, timeout=None)
+            if response.status_code != 200:
+                msg = f"[Virtuoso] Query failed {response.status_code}:\n{response.text}"
+                raise RuntimeError(msg)
+            return response.text
+
+        # UPDATE operations (INSERT, DELETE, CLEAR, DROP, LOAD, CREATE, etc.)
+        if query_type in {
+            "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
+            "MOVE", "COPY", "ADD", "MODIFY",
+        }:
+            self._run_update(sparql)
+            return None
+
+        msg = f"[Virtuoso] Unsupported SPARQL keyword: {query_type}"
+        raise RuntimeError(msg)
+
+    def clear(self) -> None:
+        """
+        Remove all data from the configured Virtuoso graph.
+        """
+        sparql = (
+            f"CLEAR GRAPH <{self.graph_uri}>"
+            if getattr(self, "graph_uri", None)
+            else "CLEAR DEFAULT"
+        )
+        self._run_update(sparql)
+
+    def _run_update(self, sparql: str) -> None:
+        """
+        Execute a SPARQL update operation.
+
+        Parameters:
+        sparql : str
+            The SPARQL update string to be sent to the server.
+
+        Raises
+        ------
+        RuntimeError
+            If the update operation fails with a non-success status code.
+        """
+        response = requests.post(self.update_url, headers=self.headers_update, data=sparql.encode("utf-8"), auth=self.auth, timeout=None)
+        if response.status_code not in {200, 201, 204}:
+            msg = f"[Virtuoso] SPARQL update failed: {response.status_code}\n{response.text}"
+            raise RuntimeError(msg)
+
+    def _ensure_endpoint_exists(self) -> None:
+        """
+        Ensure that the configured Virtuoso SPARQL endpoint is reachable.
+
+        Raises
+        ------
+        RuntimeError
+            If unable to connect to the server or if the endpoint is inaccessible.
+        """
+        try:
+            response = requests.get(self.query_url, timeout=60, auth=self.auth)
+        except requests.RequestException as e:
+            msg = f"[Virtuoso] Could not connect to Virtuoso at {self.query_url}: {e}"
+            raise RuntimeError(msg) from e
+
+        if response.status_code in {200, 401, 403}:
+            return
+
+        msg = (
+            f"[Virtuoso] SPARQL endpoint check failed at {self.query_url}: "
+            f"HTTP {response.status_code}\n{response.text}"
+        )
+        raise RuntimeError(msg)
+
+    @staticmethod
+    def _normalize_base_url(base_url: str) -> str:
+        """
+        Normalize the configured base URL by removing any trailing slashes
+        and ensuring it does not end with a SPARQL-specific path (e.g. `/sparql`).
+
+        Parameters
+        ----------
+        base_url : str
+            The base URL of the Virtuoso server as provided in the configuration.
+
+        Returns
+        -------
+        str
+            The normalized base URL without trailing slashes or `/sparql` suffix.
+        """
+        return base_url.rstrip("/").removesuffix("/sparql")
+
+    @staticmethod
+    def _default_graph_uri(name: str) -> str:
+        """
+        Construct a default graph URI based on the provided repository name.
+
+        If the given name is already a valid absolute URI, it is returned as-is.
+        Otherwise, a fallback URI is generated under the `http://example.org/` namespace.
+
+        Parameters
+        ----------
+        name : str
+            The logical name of the repository or graph.
+
+        Returns
+        -------
+        str
+            A valid graph URI derived from the given name.
+        """
+        parsed = urlparse(name)
+        if parsed.scheme and parsed.netloc:
+            return name
+        return f"http://example.org/{name}"

--- a/triplestore/src/triplestore/backends/virtuoso.py
+++ b/triplestore/src/triplestore/backends/virtuoso.py
@@ -18,6 +18,7 @@ from triplestore.utils import (
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
+    validate_rdf_term,
 )
 
 logger = logging.getLogger(__name__)
@@ -142,19 +143,23 @@ class Virtuoso(TriplestoreBackend):
             msg = f"[Virtuoso] Load failed with status {response.status_code}:\n{response.text}"
             raise RuntimeError(msg)
 
-    def add(self, s: str, p: str, o: str) -> None:
+    def add(self, s: Any, p: Any, o: Any) -> None:
         """
         Add a triple to the Virtuoso store.
 
         Parameters:
-        s : str
-            The subject URI of the triple.
-        p : str
-            The predicate URI of the triple.
-        o : str
-            The object URI of the triple.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "Virtuoso")
+        p_term = validate_rdf_term(p, "predicate", "Virtuoso")
+        o_term = validate_rdf_term(o, "object", "Virtuoso")
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"INSERT DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri
@@ -162,19 +167,39 @@ class Virtuoso(TriplestoreBackend):
         )
         self._run_update(sparql)
 
-    def delete(self, s: str, p: str, o: str) -> None:
+    def delete(self, s: Any, p: Any, o: Any) -> None:
         """
         Delete a triple from the Virtuoso store.
 
         Parameters:
-        s : str
-            The subject URI of the triple to remove.
-        p : str
-            The predicate URI of the triple to remove.
-        o : str
-            The object URI of the triple to remove.
+        s : Any
+            The subject value of the triple. Must serialize to an RDF IRI or blank node.
+        p : Any
+            The predicate value of the triple. Must serialize to an RDF IRI.
+        o : Any
+            The object value of the triple. May serialize to an RDF IRI, blank node, or literal.
+
+        Raises
+        ------
+        ValueError
+            If a blank node is provided as the subject.
         """
-        triple = f"<{s}> <{p}> <{o}> ."
+        s_term = validate_rdf_term(s, "subject", "Virtuoso")
+        p_term = validate_rdf_term(p, "predicate", "Virtuoso")
+        o_term = validate_rdf_term(o, "object", "Virtuoso")
+
+        if isinstance(s, str) and s.startswith("_:"):
+            msg = (
+                "[Virtuoso] Cannot delete triples using a blank node as subject.\n\n"
+                "Blank node identifiers (e.g. '_:b1') are local to a single SPARQL query "
+                "or update and do not represent stable, reusable identifiers.\n"
+                "Recommended alternatives:\n"
+                " - Use a persistent IRI instead of a blank node if you need to delete the triple later.\n"
+                " - Or delete using a pattern-based query (e.g. DELETE WHERE) that matches the triple.\n\n"
+            )
+            raise ValueError(msg)
+
+        triple = f"{s_term} {p_term} {o_term} ."
         sparql = (
             f"DELETE DATA {{ GRAPH <{self.graph_uri}> {{ {triple} }} }}"
             if self.graph_uri

--- a/triplestore/src/triplestore/backends/virtuoso.py
+++ b/triplestore/src/triplestore/backends/virtuoso.py
@@ -15,6 +15,7 @@ from triplestore.utils import (
     export_ask_result,
     export_rdf_result,
     export_select_results,
+    get_rdf_content_type,
     get_sparql_query_type,
     resolve_export_format,
     validate_config,
@@ -118,11 +119,15 @@ class Virtuoso(TriplestoreBackend):
 
     def load(self, filename: str) -> None:
         """
-        Load RDF triples from a Turtle (.ttl) file into a Virtuoso named graph.
+        Load RDF triples from a supported RDF file into a Virtuoso named graph.
+
+        Supported formats:
+        - .ttl: Turtle
+        - .nt: N-Triples
 
         Parameters:
         filename : str
-            Path to the Turtle (.ttl) file to be loaded.
+            Path to the RDF file to load (.ttl or .nt).
 
         Raises
         ------
@@ -134,10 +139,13 @@ class Virtuoso(TriplestoreBackend):
         if not Path(filename).exists():
             msg = f"[Virtuoso] File not found: {filename}"
             raise FileNotFoundError(msg)
+        
+        content_type = get_rdf_content_type(filename, backend_name="Virtuoso")
+        headers = {"Content-Type": content_type}
 
         rdf_data = Path(filename).read_bytes()
         params = {"graph-uri": self.graph_uri} if self.graph_uri else {}
-        response = requests.post(self.graph_store_url, headers=self.headers_load, params=params, data=rdf_data, auth=self.auth, timeout=None)
+        response = requests.post(self.graph_store_url, headers=headers, params=params, data=rdf_data, auth=self.auth, timeout=None)
 
         if response.status_code not in {200, 201, 204}:
             msg = f"[Virtuoso] Load failed with status {response.status_code}:\n{response.text}"

--- a/triplestore/src/triplestore/base.py
+++ b/triplestore/src/triplestore/base.py
@@ -21,13 +21,13 @@ class TriplestoreBackend(ABC):
         """
 
     @abstractmethod
-    def add(self, subj: str, pred: str, obj: str) -> None:
+    def add(self, subj: Any, pred: Any, obj: Any) -> None:
         """
         Add a single RDF triple to the store.
         """
 
     @abstractmethod
-    def delete(self, subj: str, pred: str, obj: str) -> None:
+    def delete(self, subj: Any, pred: Any, obj: Any) -> None:
         """
         Delete a single RDF triple from the store.
         """

--- a/triplestore/src/triplestore/registration.py
+++ b/triplestore/src/triplestore/registration.py
@@ -19,6 +19,7 @@ EXTRA_HINT = {
     "jena": "jena",
     "oxigraph": "oxigraph",
     "qlever": "qlever",
+    "rdf4j": "rdf4j",
 }
 
 

--- a/triplestore/src/triplestore/registration.py
+++ b/triplestore/src/triplestore/registration.py
@@ -20,6 +20,7 @@ EXTRA_HINT = {
     "oxigraph": "oxigraph",
     "qlever": "qlever",
     "rdf4j": "rdf4j",
+    "virtuoso": "virtuoso",
 }
 
 

--- a/triplestore/src/triplestore/registration.py
+++ b/triplestore/src/triplestore/registration.py
@@ -18,6 +18,7 @@ EXTRA_HINT = {
     "graphdb": "graphdb",
     "jena": "jena",
     "oxigraph": "oxigraph",
+    "qlever": "qlever",
 }
 
 

--- a/triplestore/src/triplestore/utils.py
+++ b/triplestore/src/triplestore/utils.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 # Copyright (C) 2025 Maira Papadopoulou
 # SPDX-License-Identifier: Apache-2.0
+import csv
+import json
 import logging
 import platform
 import subprocess
 from collections.abc import Iterable, Mapping
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -14,6 +17,27 @@ if TYPE_CHECKING:
 from triplestore.exceptions import TriplestoreMissingConfigValue
 
 logger = logging.getLogger(__name__)
+
+SPARQL_QUERY_FORMS = {"SELECT", "ASK", "CONSTRUCT", "DESCRIBE"}
+
+SPARQL_UPDATE_TYPES = {
+    "WITH", "INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP",
+    "MOVE", "COPY", "ADD", "MODIFY",
+}
+
+SPARQL_DEFAULT_EXPORT_FORMATS = {
+    "SELECT": "json",
+    "ASK": "json",
+    "CONSTRUCT": "ttl",
+    "DESCRIBE": "ttl",
+}
+
+SPARQL_ALLOWED_EXPORT_FORMATS = {
+    "SELECT": {"json", "csv"},
+    "ASK": {"json", "txt"},
+    "CONSTRUCT": {"ttl"},
+    "DESCRIBE": {"ttl"},
+}
 
 
 def detect_host_url(port: int, path: str = "", fallback: str | None = None) -> str:
@@ -87,7 +111,7 @@ def validate_config(user_config: Mapping[str, Any], *, required_keys: Iterable[s
 
     Raises
     ------
-    ValueError
+    TriplestoreMissingConfigValue
         If one or more required keys are missing.
     """
 
@@ -125,3 +149,213 @@ def validate_config(user_config: Mapping[str, Any], *, required_keys: Iterable[s
         logger.warning(msg)
 
     return normalized_config
+
+
+def get_sparql_query_type(sparql: str) -> str:
+    """
+    Determine the top-level SPARQL query or update keyword.
+    This function extracts the first meaningful keyword of a SPARQL query/update string, ignoring
+    leading PREFIX, BASE declarations and comment lines.
+
+    Parameters
+    ----------
+    sparql : str
+        The SPARQL query or update string.
+
+    Returns
+    -------
+    str
+        The uppercase top-level SPARQL keyword (e.g., 'SELECT', 'INSERT', 'ASK').
+        Returns an empty string if no valid keyword can be determined.
+    """
+    lines = [line.strip() for line in sparql.strip().splitlines() if line.strip()]
+
+    for line in lines:
+        upper = line.upper()
+        if upper.startswith(("PREFIX ", "BASE ")):
+            continue
+        if upper.startswith("#"):
+            continue
+        return line.split(None, 1)[0].upper()
+
+    return ""
+
+
+def resolve_export_format(query_type: str, *, export: bool, output_format: str | None = None, backend_name: str = "backend") -> str | None:
+    """
+    Determine and validate the export format for a SPARQL query.
+    This function resolves the effective export format based on the query type and validates it against the supported formats for that type.
+
+    Parameters
+    ----------
+    query_type : str
+        The uppercase SPARQL query type.
+    export : bool
+        Whether export has been requested.
+    output_format : str | None, optional
+        Explicit export format requested by the user. If not provided, a default format is selected based on the query type.
+    backend_name : str, default="backend"
+        Backend name used in error messages.
+
+    Returns
+    -------
+    str | None
+        The normalized export format (lowercase, without leading dot), or None if export is False.
+
+    Raises
+    ------
+    ValueError
+        If export is requested for an unsupported query type or if the requested format is not allowed for the given query type.
+    """
+    if not export:
+        return None
+
+    if query_type not in SPARQL_DEFAULT_EXPORT_FORMATS:
+        msg = f"[{backend_name}] Unsupported export format '{output_format}' for {query_type} query. "
+        raise ValueError(msg)
+
+    chosen_format = (output_format or SPARQL_DEFAULT_EXPORT_FORMATS[query_type]).lower().lstrip(".")
+    allowed_formats = SPARQL_ALLOWED_EXPORT_FORMATS.get(query_type, set())
+
+    if chosen_format not in allowed_formats:
+        msg = (
+            f"[{backend_name}] Unsupported export format '{output_format}' for {query_type} query. "
+            f"Allowed formats: {sorted(allowed_formats)}"
+        )
+        raise ValueError(msg)
+
+    return chosen_format
+
+
+def export_select_results(results: list[dict[str, str]], output_format: str, filename: str | None = None, separator: str = ",", backend_name: str = "backend") -> Path:
+    """
+    Export SELECT query results to a local file.
+    This function serializes the variable bindings returned by a SELECT query and writes them to disk in the specified format.
+
+    Parameters
+    ----------
+    results : list[dict[str, str]]
+        The SELECT query result bindings, where each dictionary represents a result row mapping variable names to their string values.
+    output_format : str
+        Export format ('json' or 'csv').
+    filename : str, optional
+        Output filename with or without extension. If not provided, a default name ('results') is used.
+    separator : str, default=","
+        Column separator to use when exporting CSV files.
+    backend_name : str, default="backend"
+        Backend name used in error messages.
+
+    Returns
+    -------
+    Path
+        The path to the generated output file.
+
+    Raises
+    ------
+    ValueError
+        If the requested export format is not supported.
+    """
+    normalized_format = output_format.lower().lstrip(".")
+    output_name = filename or "results"
+    output_path = Path(output_name).with_suffix(f".{normalized_format}")
+
+    if normalized_format == "json":
+        output_path.write_text(json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8")
+        return output_path
+
+    if normalized_format == "csv":
+        fieldnames: list[str] = []
+        for row in results:
+            for key in row:
+                if key not in fieldnames:
+                    fieldnames.append(key)
+
+        with output_path.open("w", newline="", encoding="utf-8") as file_obj:
+            writer = csv.DictWriter(file_obj, fieldnames=fieldnames, delimiter=separator)
+            writer.writeheader()
+            writer.writerows(results)
+
+        return output_path
+
+    msg = f"[{backend_name}] Unsupported SELECT export format: {output_format}"
+    raise ValueError(msg)
+
+
+def export_ask_result(result: bool, output_format: str, filename: str | None = None, backend_name: str = "backend") -> Path:
+    """
+    Export an ASK query result to a local file.
+    This function serializes the boolean result of an ASK query into the requested format and writes it to disk.
+
+    Parameters
+    ----------
+    result : bool
+        The boolean result of the ASK query.
+    output_format : str
+        Export format ('json' or 'txt').
+    filename : str, optional
+        Output filename with or without extension. If not provided, a default name ('results') is used.
+    backend_name : str, default="backend"
+        Backend name used in error messages.
+
+    Returns
+    -------
+    Path
+        The path to the generated output file.
+
+    Raises
+    ------
+    ValueError
+        If the requested export format is not supported.
+    """
+    normalized_format = output_format.lower().lstrip(".")
+    output_name = filename or "results"
+    output_path = Path(output_name).with_suffix(f".{normalized_format}")
+
+    if normalized_format == "json":
+        output_path.write_text(json.dumps({"boolean": result}, indent=2, ensure_ascii=False), encoding="utf-8")
+        return output_path
+
+    if normalized_format == "txt":
+        output_path.write_text(str(result).lower(), encoding="utf-8")
+        return output_path
+
+    msg = f"[{backend_name}] Unsupported ASK export format: {output_format}"
+    raise ValueError(msg)
+
+
+def export_rdf_result(rdf_text: str, output_format: str, filename: str | None = None, backend_name: str = "backend") -> Path:
+    """
+    Export an RDF query result to a local file.
+    This function writes the RDF serialization produced by a SPARQL query (e.g., CONSTRUCT or DESCRIBE) to disk using the specified format.
+
+    Parameters
+    ----------
+    rdf_text : str
+        The RDF serialization returned by the query.
+    output_format : str
+        Export format ('ttl').
+    filename : str, optional
+        Output filename with or without extension. If not provided, a default name ('results') is used.
+    backend_name : str, default="backend"
+        Backend name used in error messages.
+
+    Returns
+    -------
+    Path
+        The path to the generated output file.
+
+    Raises
+    ------
+    ValueError
+        If the requested export format is not supported.
+    """
+    normalized_format = output_format.lower().lstrip(".")
+    output_name = filename or "results"
+    output_path = Path(output_name).with_suffix(f".{normalized_format}")
+
+    if normalized_format == "ttl":
+        output_path.write_text(rdf_text, encoding="utf-8")
+        return output_path
+
+    msg = f"[{backend_name}] Unsupported RDF export format: {output_format}"
+    raise ValueError(msg)

--- a/triplestore/src/triplestore/utils.py
+++ b/triplestore/src/triplestore/utils.py
@@ -11,10 +11,11 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from triplestore.exceptions import TriplestoreMissingConfigValue
+from triplestore.utils_geo import export_geospatial_select_results
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
-
-from triplestore.exceptions import TriplestoreMissingConfigValue
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ SPARQL_DEFAULT_EXPORT_FORMATS = {
 }
 
 SPARQL_ALLOWED_EXPORT_FORMATS = {
-    "SELECT": {"json", "csv"},
+    "SELECT": {"json", "csv", "geojson", "kml", "kmz", "gml"},
     "ASK": {"json", "txt"},
     "CONSTRUCT": {"ttl"},
     "DESCRIBE": {"ttl"},
@@ -237,7 +238,7 @@ def export_select_results(results: list[dict[str, str]], output_format: str, fil
     results : list[dict[str, str]]
         The SELECT query result bindings, where each dictionary represents a result row mapping variable names to their string values.
     output_format : str
-        Export format ('json' or 'csv').
+        Export format ('json', 'csv', 'geojson', 'kml', 'kmz', or 'gml').
     filename : str, optional
         Output filename with or without extension. If not provided, a default name ('results') is used.
     separator : str, default=","
@@ -276,6 +277,10 @@ def export_select_results(results: list[dict[str, str]], output_format: str, fil
             writer.writerows(results)
 
         return output_path
+
+    if normalized_format in {"geojson", "kml", "kmz", "gml"}:
+        return export_geospatial_select_results(results,
+            output_format=normalized_format, output_path=output_path, backend_name=backend_name)
 
     msg = f"[{backend_name}] Unsupported SELECT export format: {output_format}"
     raise ValueError(msg)

--- a/triplestore/src/triplestore/utils.py
+++ b/triplestore/src/triplestore/utils.py
@@ -6,16 +6,14 @@ import csv
 import json
 import logging
 import platform
+import re
 import subprocess
 from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from triplestore.exceptions import TriplestoreMissingConfigValue
 from triplestore.utils_geo import export_geospatial_select_results
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
 
 logger = logging.getLogger(__name__)
 
@@ -364,3 +362,247 @@ def export_rdf_result(rdf_text: str, output_format: str, filename: str | None = 
 
     msg = f"[{backend_name}] Unsupported RDF export format: {output_format}"
     raise ValueError(msg)
+
+
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+
+def serialize_rdf_term(term: Any, backend_name: str = "backend") -> str:
+    """
+    Convert a Python value into a valid SPARQL RDF term.
+
+    Supported inputs:
+    -----------------
+    - IRI strings starting with http:// or https://
+    - Blank node identifiers starting with "_:"
+    - Plain literal values: str, int, float, bool
+    - Mapping objects for advanced literals:
+        {
+            "value": "...",
+            "datatype": "http://...",
+            "lang": "en"
+        }
+
+    Returns
+    -------
+    str
+        A SPARQL-compatible RDF term.
+
+    Raises
+    ------
+    ValueError
+        If the value cannot be converted into a valid RDF term.
+    """
+    # 1. None is invalid
+    if term is None:
+        msg = (
+            f"[{backend_name}] Invalid RDF term: received None.\n"
+            "RDF terms cannot be null. Expected one of:\n"
+            "  - IRI string (e.g. 'http://example.org/resource')\n"
+            "  - Blank node (e.g. '_:b1')\n"
+            "  - Literal value (str, int, float, bool)\n"
+            "  - Literal mapping (e.g. {'value': 'Alice', 'lang': 'en'})\n"
+            "Check that you are not passing an uninitialized variable or missing value."
+        )
+        raise ValueError(msg)
+
+    # 2. IRI
+    if isinstance(term, str) and term.startswith(("http://", "https://")):
+        if any(ch in term for ch in (" ", "<", ">", '"', "\n", "\r", "\t")):
+            msg = (
+                f"[{backend_name}] Invalid RDF IRI: {term!r}\n"
+                "The provided value looks like an IRI, but contains invalid characters.\n\n"
+                "IRIs must:\n"
+                "  - start with 'http://' or 'https://'\n"
+                "  - not contain spaces or control characters\n"
+                "  - not include '<', '>', or '\"' (these are added automatically in SPARQL)\n\n"
+                "Examples of valid IRIs:\n"
+                "  - http://example.org/Alice\n"
+            )
+            raise ValueError(msg)
+        return f"<{term}>"
+
+    # 3. Blank node
+    if isinstance(term, str) and term.startswith("_:"):
+        if not re.fullmatch(r"_:[A-Za-z0-9_]+", term):
+            msg = (
+                f"[{backend_name}] Invalid RDF blank node identifier: {term!r}\n"
+                "The provided value is intended to be a blank node, but its format is invalid.\n\n"
+                "Blank node identifiers must:\n"
+                "  - start with '_:'\n"
+                "  - be followed by letters, digits, or underscores only\n"
+                "  - not contain spaces or special characters\n\n"
+                "Examples of valid blank nodes:\n"
+                "  - _:b1\n"
+            )
+            raise ValueError(msg)
+        return term
+
+    # 4. Boolean
+    if isinstance(term, bool):
+        return f'"{str(term).lower()}"^^<{XSD_NS}boolean>'
+
+    # 5. Integer
+    if isinstance(term, int):
+        return f'"{term}"^^<{XSD_NS}integer>'
+
+    # 6. Float
+    if isinstance(term, float):
+        return f'"{term}"^^<{XSD_NS}double>'
+
+    # 7. Advanced literal (Mapping)
+    if isinstance(term, Mapping):
+        value = term.get("value")
+        datatype = term.get("datatype")
+        lang = term.get("lang")
+
+        if value is None:
+            msg = (
+                f"[{backend_name}] Invalid literal mapping: missing 'value'.\n"
+                "A literal mapping must always define a 'value' key.\n\n"
+                "Expected examples:\n"
+                "  - {'value': 'Alice'}\n"
+                "  - {'value': 'Alice', 'lang': 'en'}\n"
+                "  - {'value': '25', 'datatype': 'http://www.w3.org/2001/XMLSchema#integer'}"
+            )
+            raise ValueError(msg)
+
+        if datatype and lang:
+            msg = (
+                f"[{backend_name}] Invalid literal mapping: both 'datatype' and 'lang' were provided.\n"
+                "An RDF literal can be either:\n"
+                '  - a datatype literal (e.g. "25"^^xsd:integer), or\n'
+                '  - a language-tagged literal (e.g. "hello"@en),\n'
+                "but not both at the same time.\n\n"
+            )
+            raise ValueError(msg)
+
+        escaped = _escape_literal(str(value))
+
+        if datatype is not None:
+            if not isinstance(datatype, str) or not datatype.startswith(("http://", "https://")):
+                msg = (
+                    f"[{backend_name}] Invalid datatype IRI: {datatype!r}\n"
+                    "The 'datatype' field must be a full IRI string starting with "
+                    "'http://' or 'https://'.\n\n"
+                    "Example:\n"
+                    "  {'value': '25', 'datatype': 'http://www.w3.org/2001/XMLSchema#integer'}"
+                )
+                raise ValueError(msg)
+            if any(ch in datatype for ch in (" ", "<", ">", '"', "\n", "\r", "\t")):
+                msg = (
+                    f"[{backend_name}] Invalid datatype IRI: {datatype!r}\n"
+                    "Datatype IRIs must not contain spaces, quotes, angle brackets, "
+                    "or control characters.\n\n"
+                )
+                raise ValueError(msg)
+            return f'"{escaped}"^^<{datatype}>'
+
+        if lang is not None:
+            if not isinstance(lang, str) or not re.fullmatch(r"[A-Za-z]{2,8}(-[A-Za-z0-9]{1,8})*", lang):
+                msg = (
+                    f"[{backend_name}] Invalid language tag: {lang!r}\n"
+                    "The 'lang' field must be a valid language tag such as:\n"
+                    "  - en\n"
+                    "  - en-GB\n"
+                    "Example:\n"
+                    "  {'value': 'hello', 'lang': 'en'}"
+                )
+                raise ValueError(msg)
+            return f'"{escaped}"@{lang}'
+
+        return f'"{escaped}"'
+
+    # 8. String literal
+    if isinstance(term, str):
+        return f'"{_escape_literal(term)}"'
+
+    # 9. Unsupported type
+    msg = (
+        f"[{backend_name}] Unsupported RDF term type: {type(term).__name__}\n"
+        f"Received value: {term!r}\n\n"
+        "This value cannot be converted into a valid RDF term.\n\n"
+        "Supported input types are:\n"
+        "  - IRI string (e.g. 'http://example.org/resource')\n"
+        "  - Blank node identifier (e.g. '_:b1')\n"
+        "  - Literal values:\n"
+        "      • str (e.g. 'Alice')\n"
+        "      • int (e.g. 25)\n"
+        "      • float (e.g. 3.14)\n"
+        "      • bool (e.g. True / False)\n"
+        "  - Literal mapping (e.g. {'value': 'Alice', 'lang': 'en'})\n\n"
+    )
+    raise ValueError(msg)
+
+
+def validate_rdf_term(term: Any, position: str, backend_name: str = "backend") -> str:
+    """
+    Validate that a Python value is allowed in the given RDF triple position
+    and return its serialized SPARQL RDF term.
+
+    Parameters
+    ----------
+    term : Any
+        The Python value to validate.
+    position : str
+        The RDF triple position: 'subject', 'predicate', or 'object'.
+    backend_name : str, default="backend"
+        Backend name used in error messages.
+
+    Returns
+    -------
+    str
+        The validated RDF term serialized in SPARQL-compatible form.
+
+    Raises
+    ------
+    ValueError
+        If the position is invalid or if the term is not allowed in that RDF position.
+    """
+    serialized = serialize_rdf_term(term, backend_name=backend_name)
+
+    is_iri = serialized.startswith("<") and serialized.endswith(">")
+    is_literal = serialized.startswith('"')
+
+    if position == "subject":
+        if is_literal:
+            msg = (
+                f"[{backend_name}] Invalid RDF subject: {term!r}\n"
+                "The subject of an RDF triple cannot be a literal.\n\n"
+                "A subject must be one of:\n"
+                "  - an IRI string (e.g. 'http://example.org/Alice')\n"
+                "  - a blank node identifier (e.g. '_:b1')\n\n"
+                "Examples of valid RDF subjects:\n"
+                "  - http://example.org/Alice\n"
+                "  - _:b1\n\n"
+            )
+            raise ValueError(msg)
+        return serialized
+
+    if position == "predicate":
+        if not is_iri:
+            msg = (
+                f"[{backend_name}] Invalid RDF predicate: {term!r}\n"
+                "The predicate of an RDF triple must be an IRI.\n\n"
+                "Predicates represent properties or relationships, so RDF does not allow "
+                "literals or blank nodes in predicate position.\n\n"
+                "A valid predicate must be an IRI string such as:\n"
+                "  - 'http://example.org/knows'\n"
+                "  - 'http://example.org/age'\n\n"
+            )
+            raise ValueError(msg)
+        return serialized
+
+    if position == "object":
+        return serialized
+
+
+def _escape_literal(value: str) -> str:
+    return (
+        value
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )

--- a/triplestore/src/triplestore/utils.py
+++ b/triplestore/src/triplestore/utils.py
@@ -38,6 +38,11 @@ SPARQL_ALLOWED_EXPORT_FORMATS = {
     "DESCRIBE": {"ttl"},
 }
 
+RDF_CONTENT_TYPES = {
+    ".ttl": "text/turtle",
+    ".nt": "application/n-triples",
+}
+
 
 def detect_host_url(port: int, path: str = "", fallback: str | None = None) -> str:
     """
@@ -606,3 +611,41 @@ def _escape_literal(value: str) -> str:
         .replace("\r", "\\r")
         .replace("\t", "\\t")
     )
+
+
+def get_rdf_content_type(filename: str, backend_name: str = "backend") -> str:
+    """
+    Determine the appropriate HTTP Content-Type header for an RDF file.
+
+    Supported formats:
+    - .ttl -> text/turtle
+    - .nt  -> application/n-triples
+
+    Parameters
+    ----------
+    filename : str
+        Path to the RDF file.
+    backend_name : str, default="backend"
+        Backend name used in error messages.
+
+    Returns
+    -------
+    str
+        The corresponding Content-Type for the RDF file.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not supported.
+    """
+    suffix = Path(filename).suffix.lower()
+
+    try:
+        return RDF_CONTENT_TYPES[suffix]
+    except KeyError as exc:
+        supported = ", ".join(sorted(RDF_CONTENT_TYPES))
+        msg = (
+            f"[{backend_name}] Unsupported RDF file format: '{suffix}'. "
+            f"Supported formats: {supported}"
+        )
+        raise ValueError(msg) from exc

--- a/triplestore/src/triplestore/utils_geo.py
+++ b/triplestore/src/triplestore/utils_geo.py
@@ -1,0 +1,698 @@
+from __future__ import annotations
+
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+import json
+import xml.etree.ElementTree as ET
+import zipfile
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from shapely import wkt
+from shapely.geometry import mapping
+
+
+def _looks_like_geojson(value: Any) -> bool:
+    """
+    Check whether a value appears to be a valid GeoJSON object.
+
+    Parameters
+    ----------
+    value : Any
+        The value to inspect.
+
+    Returns
+    -------
+    bool
+        True if the value resembles a GeoJSON geometry or feature object,
+        False otherwise.
+    """
+    if not isinstance(value, dict):
+        return False
+
+    geojson_type = value.get("type")
+    if not isinstance(geojson_type, str):
+        return False
+
+    valid_types = {"Point", "MultiPoint", "LineString", "MultiLineString",
+                   "Polygon", "MultiPolygon", "GeometryCollection", "Feature", "FeatureCollection"}
+    return geojson_type in valid_types
+
+
+def _parse_geojson_value(value: str, *, backend_name: str) -> dict[str, Any]:
+    """
+    Parse a string value as GeoJSON and return the decoded object.
+
+    Parameters
+    ----------
+    value : str
+        The string value to parse as GeoJSON.
+    backend_name : str
+        Backend name used in error messages.
+
+    Returns
+    -------
+    dict[str, Any]
+        The parsed GeoJSON object.
+
+    Raises
+    ------
+    ValueError
+        If the value is not valid JSON or does not represent a supported GeoJSON object.
+    """
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        msg = (
+            f"[{backend_name}] Cannot export result to GeoJSON because a result value "
+            "is not valid JSON. Expected a GeoJSON geometry, Feature, or "
+            "FeatureCollection encoded as a JSON string."
+        )
+        raise ValueError(msg) from exc
+
+    if not _looks_like_geojson(parsed):
+        msg = (
+            f"[{backend_name}] Cannot export result to GeoJSON because a result value "
+            "is valid JSON but not a supported GeoJSON object. Expected a GeoJSON "
+            "geometry, Feature, or FeatureCollection with a valid 'type' field."
+        )
+        raise ValueError(msg)
+
+    return parsed
+
+
+def _strip_typed_literal(value: str) -> str:
+    """
+    Normalize an RDF literal by removing quotes and datatype suffix.
+    It is primarily used to prepare WKT literals for geometry parsing.
+
+    Parameters
+    ----------
+    value : str
+        The literal value to normalize.
+
+    Returns
+    -------
+    str
+        The extracted literal value without surrounding quotes or datatype suffix.
+    """
+    text = value.strip()
+
+    if text.startswith('"') and '"^^' in text:
+        return text[1:text.index('"^^')]
+
+    if text.startswith('"') and text.endswith('"'):
+        return text[1:-1]
+
+    return text
+
+
+def _parse_wkt_value(value: str, *, backend_name: str) -> dict[str, Any]:
+    """
+    Parse a WKT literal and convert it to a GeoJSON geometry object.
+
+    Parameters
+    ----------
+    value : str
+        The WKT literal value to parse.
+    backend_name : str
+        Backend name used in error messages.
+
+    Returns
+    -------
+    dict[str, Any]
+        The parsed geometry as a GeoJSON-style dictionary.
+
+    Raises
+    ------
+    ValueError
+        If the input value cannot be parsed as WKT or cannot be converted to a GeoJSON geometry object.
+    """
+    text = _strip_typed_literal(value)
+
+    try:
+        geometry = wkt.loads(text)
+    except Exception as exc:
+        msg = (
+            f"[{backend_name}] Cannot export result to GeoJSON because result value "
+            "could not be parsed as WKT geometry. Expected a valid WKT value such as "
+            "'POINT(x y)', 'LINESTRING(...)', or 'POLYGON(...)'."
+        )
+        raise ValueError(msg) from exc
+
+    try:
+        return dict(mapping(geometry))
+    except Exception as exc:
+        msg = (
+            f"[{backend_name}] Cannot export result to GeoJSON because the parsed WKT "
+            "geometry could not be converted to a GeoJSON geometry object."
+        )
+        raise ValueError(msg) from exc
+
+
+def _build_feature_rows(results: list[dict[str, str]], *, backend_name: str) -> list[dict[str, Any]]:
+    """
+    Convert SELECT result rows to normalized GeoJSON-like Feature objects.
+
+    Parameters
+    ----------
+    results : list[dict[str, str]]
+        The SELECT query result bindings, where each dictionary represents a result row mapping variable names to string values.
+    backend_name : str
+        Backend name used in error messages.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        A list of normalized GeoJSON-like Feature objects, one for each input row.
+
+    Raises
+    ------
+    ValueError
+        If a row does not contain a supported geometry value, contains more than
+        one geometry column, or contains a FeatureCollection value instead of a
+        single geometry or Feature.
+    """
+    features: list[dict[str, Any]] = []
+
+    for row in results:
+        geometry_column = None
+        geometry_value = None
+
+        for key, value in row.items():
+            try:
+                parsed = _parse_geojson_value(value, backend_name=backend_name)
+            except ValueError:
+                continue
+
+            if geometry_column is not None:
+                msg = (
+                    f"[{backend_name}] Cannot export SELECT results as geospatial data because "
+                    "a result row contains more than one geometry column. Each row must contain "
+                    "exactly one GeoJSON or WKT geometry value."
+                )
+                raise ValueError(msg)
+
+            geometry_column = key
+            geometry_value = parsed
+
+        if geometry_column is None:
+            for key, value in row.items():
+                try:
+                    parsed = _parse_wkt_value(value, backend_name=backend_name)
+                except ValueError:
+                    continue
+
+                if geometry_column is not None:
+                    msg = (
+                        f"[{backend_name}] Cannot export SELECT results as geospatial data because "
+                        "a result row contains more than one geometry column. Each row must contain "
+                        "exactly one GeoJSON or WKT geometry value."
+                    )
+                    raise ValueError(msg)
+
+                geometry_column = key
+                geometry_value = parsed
+
+        if geometry_column is None or geometry_value is None:
+            msg = (
+                f"[{backend_name}] Cannot export SELECT results as geospatial data because "
+                "a result row does not contain any supported geometry value. Expected "
+                "exactly one GeoJSON geometry, GeoJSON Feature, or WKT literal per row."
+            )
+            raise ValueError(msg)
+
+        if geometry_value["type"] == "Feature":
+            feature = geometry_value.copy()
+            existing_properties = feature.get("properties", {})
+            extra_properties = {k: v for k, v in row.items() if k != geometry_column}
+            feature["properties"] = {**existing_properties, **extra_properties}
+            features.append(feature)
+            continue
+
+        if geometry_value["type"] == "FeatureCollection":
+            msg = (
+                f"[{backend_name}] Cannot export SELECT results as geospatial data because "
+                "a single result row contains a GeoJSON FeatureCollection. Each row must "
+                "represent exactly one geometry or one GeoJSON Feature."
+            )
+            raise ValueError(msg)
+
+        properties = {k: v for k, v in row.items() if k != geometry_column}
+        features.append({
+            "type": "Feature",
+            "geometry": geometry_value,
+            "properties": properties,
+        })
+
+    return features
+
+
+def _build_geojson_feature_collection(results: list[dict[str, str]], *, backend_name: str) -> dict[str, Any]:
+    """
+    Build a GeoJSON FeatureCollection from SELECT result rows.
+
+    Parameters
+    ----------
+    results : list[dict[str, str]]
+        The SELECT query result bindings, where each dictionary represents a result row mapping variable names to string values.
+    backend_name : str
+        Backend name used in error messages.
+
+    Returns
+    -------
+    dict[str, Any]
+        A GeoJSON FeatureCollection containing one Feature for each input row.
+    """
+    return {
+        "type": "FeatureCollection",
+        "features": _build_feature_rows(results, backend_name=backend_name),
+    }
+
+
+def _format_coords(coord: list[float], *, separator: str, require_2d_or_3d: bool = False) -> str:
+    """
+    Format a coordinate list into a string using the given separator.
+
+    Parameters
+    ----------
+    coord : list[float]
+        The coordinate to format.
+    separator : str
+        The separator to use between coordinate values.
+    require_2d_or_3d : bool, default=False
+        If True, validate that the coordinate contains exactly 2 or 3 values.
+
+    Returns
+    -------
+    str
+        The formatted coordinate string.
+
+    Raises
+    ------
+    ValueError
+        If validation is enabled and the coordinate does not contain 2 or 3 values.
+    """
+    if require_2d_or_3d and len(coord) not in {2, 3}:
+        msg = (
+            "Invalid coordinate for export. Expected either 2 values (x, y) or "
+            f"3 values (x, y, z), but got {len(coord)} values: {coord!r}."
+        )
+        raise ValueError(msg)
+
+    return separator.join(str(x) for x in coord)
+
+
+def _coords_to_kml(coord: list[float]) -> str:
+    """
+    Convert a coordinate list to KML coordinate text.
+
+    Parameters
+    ----------
+    coord : list[float]
+        The coordinate to format.
+
+    Returns
+    -------
+    str
+        The coordinate formatted as comma-separated KML coordinate text.
+    """
+    return _format_coords(coord, separator=",", require_2d_or_3d=True)
+
+
+def _geometry_to_kml_element(geometry: dict[str, Any]) -> ET.Element:
+    """
+    Convert a GeoJSON-like geometry object to a KML XML element.
+
+    Parameters
+    ----------
+    geometry : dict[str, Any]
+        The GeoJSON-like geometry object to convert. The input is expected to
+        contain at least a geometry "type" and its corresponding "coordinates".
+
+    Returns
+    -------
+    xml.etree.ElementTree.Element
+        The generated KML XML element representing the input geometry.
+
+    Raises
+    ------
+    ValueError
+        If the geometry type is not supported for KML export.
+    """
+    geom_type = geometry["type"]
+    coords = geometry["coordinates"]
+
+    if geom_type == "Point":
+        point_el = ET.Element("Point")
+        ET.SubElement(point_el, "coordinates").text = _coords_to_kml(coords)
+        return point_el
+
+    if geom_type == "LineString":
+        line_el = ET.Element("LineString")
+        ET.SubElement(line_el, "coordinates").text = " ".join(_coords_to_kml(c) for c in coords)
+        return line_el
+
+    if geom_type == "Polygon":
+        poly_el = ET.Element("Polygon")
+
+        outer = ET.SubElement(poly_el, "outerBoundaryIs")
+        outer_ring = ET.SubElement(outer, "LinearRing")
+        ET.SubElement(outer_ring, "coordinates").text = " ".join(_coords_to_kml(c) for c in coords[0])
+
+        for ring in coords[1:]:
+            inner = ET.SubElement(poly_el, "innerBoundaryIs")
+            inner_ring = ET.SubElement(inner, "LinearRing")
+            ET.SubElement(inner_ring, "coordinates").text = " ".join(_coords_to_kml(c) for c in ring)
+
+        return poly_el
+
+    if geom_type == "MultiPoint":
+        multi = ET.Element("MultiGeometry")
+        for point in coords:
+            multi.append(_geometry_to_kml_element({"type": "Point", "coordinates": point}))
+        return multi
+
+    if geom_type == "MultiLineString":
+        multi = ET.Element("MultiGeometry")
+        for line in coords:
+            multi.append(_geometry_to_kml_element({"type": "LineString", "coordinates": line}))
+        return multi
+
+    if geom_type == "MultiPolygon":
+        multi = ET.Element("MultiGeometry")
+        for poly in coords:
+            multi.append(_geometry_to_kml_element({"type": "Polygon", "coordinates": poly}))
+        return multi
+
+    msg = (
+        "Cannot export geometry to KML because the geometry type is not supported. "
+        f"Got {geom_type!r}. Supported types are: 'Point', 'LineString', 'Polygon', "
+        "'MultiPoint', 'MultiLineString', and 'MultiPolygon'."
+    )
+    raise ValueError(msg)
+
+
+def _build_kml_document(results: list[dict[str, str]], *, backend_name: str) -> str:
+    """
+    Build a KML document from SELECT result rows.
+
+    Parameters
+    ----------
+    results : list[dict[str, str]]
+        The SELECT query result bindings, where each dictionary represents a result row mapping variable names to string values.
+    backend_name : str
+        Backend name used in error messages.
+
+    Returns
+    -------
+    str
+        The generated KML document as a formatted XML string.
+
+    Raises
+    ------
+    ValueError
+        If the result rows cannot be converted to valid feature objects or if any geometry cannot be represented in KML.
+    """
+    try:
+        features = _build_feature_rows(results, backend_name=backend_name)
+    except ValueError as exc:
+        msg = (
+            f"[{backend_name}] Cannot export SELECT results to KML because one or more "
+            "result rows could not be converted to valid geospatial features."
+        )
+        raise ValueError(msg) from exc
+
+    kml = ET.Element("kml", xmlns="http://www.opengis.net/kml/2.2")
+    document = ET.SubElement(kml, "Document")
+
+    for idx, feature in enumerate(features, start=1):
+        placemark = ET.SubElement(document, "Placemark")
+
+        props = feature.get("properties", {})
+        name_value = props.get("name") or props.get("feature") or f"feature-{idx}"
+        ET.SubElement(placemark, "name").text = str(name_value)
+
+        if props:
+            extended = ET.SubElement(placemark, "ExtendedData")
+            for key, value in props.items():
+                data_el = ET.SubElement(extended, "Data", name=str(key))
+                ET.SubElement(data_el, "value").text = str(value)
+
+        try:
+            placemark.append(_geometry_to_kml_element(feature["geometry"]))
+        except ValueError as exc:
+            msg = (
+                f"[{backend_name}] Cannot export SELECT results to KML because one or more "
+                "feature geometries use a format that is not supported in KML export."
+            )
+            raise ValueError(msg) from exc
+
+    try:
+        ET.indent(kml, space="  ")
+        return ET.tostring(kml, encoding="unicode")
+    except Exception as exc:
+        msg = (
+            f"[{backend_name}] Failed to generate the final KML document due to an XML "
+            "serialization error."
+        )
+        raise ValueError(msg) from exc
+
+
+def _coords_to_gml_pos(coord: list[float]) -> str:
+    """
+    Convert a coordinate list to GML position text.
+
+    Parameters
+    ----------
+    coord : list[float]
+        The coordinate to format.
+
+    Returns
+    -------
+    str
+        The coordinate formatted as whitespace-separated GML position text.
+    """
+    return _format_coords(coord, separator=" ")
+
+
+def _geometry_to_gml_element(geometry: dict[str, Any]) -> ET.Element:
+    """
+    Convert a GeoJSON-like geometry object to a GML XML element.
+
+    Parameters
+    ----------
+    geometry : dict[str, Any]
+        The GeoJSON-like geometry object to convert. The input is expected to
+        contain at least a geometry ``type`` and its corresponding ``coordinates``.
+
+    Returns
+    -------
+    xml.etree.ElementTree.Element
+        The generated GML XML element representing the input geometry.
+
+    Raises
+    ------
+    ValueError
+        If the geometry type is not supported for GML export.
+    """
+    geom_type = geometry["type"]
+    coords = geometry["coordinates"]
+
+    ns = "http://www.opengis.net/gml"
+
+    if geom_type == "Point":
+        point_el = ET.Element(f"{{{ns}}}Point")
+        ET.SubElement(point_el, f"{{{ns}}}pos").text = _coords_to_gml_pos(coords)
+        return point_el
+
+    if geom_type == "LineString":
+        line_el = ET.Element(f"{{{ns}}}LineString")
+        ET.SubElement(line_el, f"{{{ns}}}posList").text = " ".join(_coords_to_gml_pos(c) for c in coords)
+        return line_el
+
+    if geom_type == "Polygon":
+        poly_el = ET.Element(f"{{{ns}}}Polygon")
+
+        exterior = ET.SubElement(poly_el, f"{{{ns}}}exterior")
+        outer_ring = ET.SubElement(exterior, f"{{{ns}}}LinearRing")
+        ET.SubElement(outer_ring, f"{{{ns}}}posList").text = " ".join(_coords_to_gml_pos(c) for c in coords[0])
+
+        for ring in coords[1:]:
+            interior = ET.SubElement(poly_el, f"{{{ns}}}interior")
+            inner_ring = ET.SubElement(interior, f"{{{ns}}}LinearRing")
+            ET.SubElement(inner_ring, f"{{{ns}}}posList").text = " ".join(_coords_to_gml_pos(c) for c in ring)
+
+        return poly_el
+
+    if geom_type == "MultiPoint":
+        multi = ET.Element(f"{{{ns}}}MultiPoint")
+        for point in coords:
+            member = ET.SubElement(multi, f"{{{ns}}}pointMember")
+            member.append(_geometry_to_gml_element({"type": "Point", "coordinates": point}))
+        return multi
+
+    if geom_type == "MultiLineString":
+        multi = ET.Element(f"{{{ns}}}MultiLineString")
+        for line in coords:
+            member = ET.SubElement(multi, f"{{{ns}}}lineStringMember")
+            member.append(_geometry_to_gml_element({"type": "LineString", "coordinates": line}))
+        return multi
+
+    if geom_type == "MultiPolygon":
+        multi = ET.Element(f"{{{ns}}}MultiPolygon")
+        for poly in coords:
+            member = ET.SubElement(multi, f"{{{ns}}}polygonMember")
+            member.append(_geometry_to_gml_element({"type": "Polygon", "coordinates": poly}))
+        return multi
+
+    msg = (
+        "Cannot export geometry to GML because the geometry type is not supported. "
+        f"Got {geom_type!r}. Supported types are: 'Point', 'LineString', 'Polygon', "
+        "'MultiPoint', 'MultiLineString', and 'MultiPolygon'."
+    )
+    raise ValueError(msg)
+
+
+def _build_gml_document(results: list[dict[str, str]], *, backend_name: str) -> str:
+    """
+    Build a GML document from SELECT result rows.
+    The resulting XML document is returned as a formatted string.
+
+    Parameters
+    ----------
+    results : list[dict[str, str]]
+        The SELECT query result bindings, where each dictionary represents a result row mapping variable names to string values.
+    backend_name : str
+        Backend name used in error messages.
+
+    Returns
+    -------
+    str
+        The generated GML document as a formatted XML string.
+
+    Raises
+    ------
+    ValueError
+        If the result rows cannot be converted to valid feature objects or if
+        any geometry cannot be represented in GML.
+    """
+    try:
+        features = _build_feature_rows(results, backend_name=backend_name)
+    except ValueError as exc:
+        msg = (
+            f"[{backend_name}] Cannot export SELECT results to GML because one or more "
+            "result rows could not be converted to valid geospatial features."
+        )
+        raise ValueError(msg) from exc
+
+    ns_gml = "http://www.opengis.net/gml"
+    ns_ex = "http://example.org/gml-export"
+
+    ET.register_namespace("gml", ns_gml)
+    ET.register_namespace("ts", ns_ex)
+
+    root = ET.Element(f"{{{ns_ex}}}FeatureCollection")
+
+    for idx, feature in enumerate(features, start=1):
+        member = ET.SubElement(root, f"{{{ns_gml}}}featureMember")
+        feat_el = ET.SubElement(member, f"{{{ns_ex}}}Feature", attrib={"fid": f"f{idx}"})
+
+        props = feature.get("properties", {})
+        for key, value in props.items():
+            ET.SubElement(feat_el, f"{{{ns_ex}}}{key}").text = str(value)
+
+        geom_prop = ET.SubElement(feat_el, f"{{{ns_ex}}}geometry")
+        try:
+            geom_prop.append(_geometry_to_gml_element(feature["geometry"]))
+        except ValueError as exc:
+            msg = (
+                f"[{backend_name}] Cannot export SELECT results to GML because one or more "
+                "feature geometries use a format that is not supported in GML export."
+            )
+            raise ValueError(msg) from exc
+
+    try:
+        ET.indent(root, space="  ")
+        return ET.tostring(root, encoding="unicode")
+    except Exception as exc:
+        msg = (
+            f"[{backend_name}] Failed to generate the final GML document due to an XML "
+            "serialization error."
+        )
+        raise ValueError(msg) from exc
+
+
+def _write_kmz_archive(kml_text: str, output_path: Path) -> Path:
+    """
+    Write a KMZ archive containing a KML document.
+
+    Parameters
+    ----------
+    kml_text : str
+        The KML document content to include in the archive.
+    output_path : Path
+        The output path for the generated ``.kmz`` file.
+
+    Returns
+    -------
+    Path
+        The path to the generated KMZ archive.
+    """
+    with zipfile.ZipFile(output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as kmz_file:
+        kmz_file.writestr("doc.kml", kml_text)
+
+    return output_path
+
+
+def export_geospatial_select_results(results: list[dict[str, str]], *, output_format: str, output_path: Path,
+                                     backend_name: str = "backend") -> Path:
+    """
+    Export geospatial SELECT query results to a local file.
+
+    Parameters
+    ----------
+    results : list[dict[str, str]]
+        The SELECT query result bindings.
+    output_format : str
+        Export format ('geojson', 'kml', 'kmz', or 'gml').
+    output_path : Path
+        The output file path.
+    backend_name : str, default="backend"
+        Backend name used in error messages.
+
+    Returns
+    -------
+    Path
+        The path to the generated output file.
+
+    Raises
+    ------
+    ValueError
+        If the requested geospatial export format is not supported.
+    """
+    normalized_format = output_format.lower().lstrip(".")
+
+    if normalized_format == "geojson":
+        feature_collection = _build_geojson_feature_collection(results, backend_name=backend_name)
+        output_path.write_text(json.dumps(feature_collection, indent=2, ensure_ascii=False), encoding="utf-8")
+        return output_path
+
+    if normalized_format == "kml":
+        kml_text = _build_kml_document(results, backend_name=backend_name)
+        output_path.write_text(kml_text, encoding="utf-8")
+        return output_path
+
+    if normalized_format == "kmz":
+        kml_text = _build_kml_document(results, backend_name=backend_name)
+        return _write_kmz_archive(kml_text, output_path)
+
+    if normalized_format == "gml":
+        gml_text = _build_gml_document(results, backend_name=backend_name)
+        output_path.write_text(gml_text, encoding="utf-8")
+        return output_path
+
+    msg = f"[{backend_name}] Unsupported geospatial export format: {output_format}"
+    raise ValueError(msg)

--- a/triplestore/tests/test_all_backends.py
+++ b/triplestore/tests/test_all_backends.py
@@ -13,6 +13,7 @@ def main() -> int:
         "triplestore/tests/test_graphdb.py",
         "triplestore/tests/test_blazegraph.py",
         "triplestore/tests/test_allegrograph.py",
+        "triplestore/tests/test_qlever.py"
     ]
 
     # Allow passing through extra pytest args, e.g. -q or -k pattern

--- a/triplestore/tests/test_allegrograph.py
+++ b/triplestore/tests/test_allegrograph.py
@@ -217,7 +217,7 @@ def test_execute():
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
 
 
-def test_select_star_returns_all_bound_variables_for_multiple_triples():
+def test_select_star():
     """Test SELECT *: verifies correct binding, completeness, and result integrity."""
     store = Triplestore("allegrograph", config=config)
     store.clear()

--- a/triplestore/tests/test_allegrograph.py
+++ b/triplestore/tests/test_allegrograph.py
@@ -107,6 +107,133 @@ def test_query_roundtrip_add():
     assert count == 1
 
 
+def test_add_delete_with_literal_object():
+    """Test add()/delete() with a plain string literal object."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    s = "http://example.org/person1"
+    p = "http://example.org/name"
+    o = "Alice"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Alice"
+
+    store.delete(s, p, o)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+    assert results_after_delete == []
+
+
+def test_add_delete_with_typed_and_lang_literals():
+    """Test add()/delete() with typed and language-tagged literal objects."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    s1 = "http://example.org/person2"
+    p1 = "http://example.org/age"
+    o1 = 25
+
+    s2 = "http://example.org/person3"
+    p2 = "http://example.org/label"
+    o2 = {"value": "hallo", "lang": "de"}
+
+    store.add(s1, p1, o1)
+    store.add(s2, p2, o2)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results)
+    assert any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results)
+
+    store.delete(s1, p1, o1)
+    store.delete(s2, p2, o2)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert not any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results_after_delete)
+    assert not any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results_after_delete)
+
+
+def test_add_delete_with_blank_node_subject():
+    """Test add()/delete() with a blank node as subject."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    s = "_:b1"
+    p = "http://example.org/name"
+    o = "Anonymous"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Anonymous"
+
+    with pytest.raises(ValueError, match="Cannot delete triples using a blank node as subject."):
+        store.delete(s, p, o)
+
+
+def test_add_rejects_invalid_rdf_positions():
+    """Test that add() rejects literals as subjects and non-IRI predicates."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="subject of an RDF triple cannot be a literal"):
+        store.add("Alice", "http://example.org/name", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "_:p1", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "name", "Bob")
+
+
 def test_query_returns_empty_when_no_match():
     """Test that a SPARQL query returns no results when no match exists."""
     store = Triplestore("allegrograph", config=config)

--- a/triplestore/tests/test_allegrograph.py
+++ b/triplestore/tests/test_allegrograph.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import pytest
 import requests
-
 from triplestore import Triplestore
 
 # SPARQL Test Data
@@ -216,3 +215,52 @@ def test_execute():
     clr_out = store.execute(q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_select_star_returns_all_bound_variables_for_multiple_triples():
+    """Test SELECT *: verifies correct binding, completeness, and result integrity."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    # Insert multiple triples
+    triples = [
+        ("http://example.org/s1", "http://example.org/p1", "http://example.org/o1"),
+        ("http://example.org/s2", "http://example.org/p2", "http://example.org/o2"),
+        ("http://example.org/s3", "http://example.org/p3", "http://example.org/o3"),
+    ]
+
+    for s, p, o in triples:
+        store.add(s, p, o)
+
+    # SELECT * query
+    results = store.query(
+        f"""
+        SELECT * WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    # Check number of results
+    assert len(results) == len(triples)
+
+    expected_rows = [{"s": s, "p": p, "o": o} for s, p, o in triples]
+
+    # Check that all variables are present in each row
+    for row in results:
+        assert set(row.keys()) == {"s", "p", "o"}
+
+    # Check that all values are valid (strings and not None)
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Check exact match between expected and actual results (order-independent)
+    assert {tuple(sorted(r.items())) for r in results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # Ensure no duplicate rows are returned
+    assert len(results) == len({tuple(sorted(r.items())) for r in results})

--- a/triplestore/tests/test_allegrograph.py
+++ b/triplestore/tests/test_allegrograph.py
@@ -7,7 +7,8 @@ Tests for the AllegroGraph backend of the triplestore abstraction layer.
 All operations are scoped within the named graph 'http://example.org/test',
 and use a local AllegroGraph instance with SPARQL HTTP API access.
 """
-
+import csv
+import json
 import tempfile
 import time
 from pathlib import Path
@@ -24,6 +25,9 @@ SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p 
 
 # Repository configuration
 REPO_NAME = f"testns-{int(time.time())}"
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 # Connection configuration
@@ -264,3 +268,507 @@ def test_select_star():
 
     # Ensure no duplicate rows are returned
     assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
+def test_query_export_json():
+    """Test that query() exports SELECT results to a JSON file correctly."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "allegrograph_results1"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_results1.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data == results
+
+    row = data[0]
+    assert row["s"] == SUBJECT
+    assert row["p"] == PREDICATE
+    assert row["o"] == OBJECT
+
+
+def test_query_export_csv():
+    """Test that query() exports SELECT results to a CSV file correctly."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "allegrograph_results2"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_results2.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_export_csv_with_custom_separator():
+    """Test that query() exports SELECT results to CSV using a custom separator."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    # Check raw file content for separator
+    content = exported_path.read_text()
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_query_export_json_with_existing_extension():
+    """Test that query() respects an already-correct filename extension."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "already_json.json"
+    store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    assert output_file.exists()
+    assert not (TEST_FILES_DIR / "already_json.json.json").exists()
+
+
+def test_query_export_replaces_wrong_extension():
+    """Test that query() replaces a wrong filename extension with the requested one."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "results.txt"
+    store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    assert not output_file.exists()
+    assert (TEST_FILES_DIR / "results.csv").exists()
+
+
+def test_query_export_empty_results_json():
+    """Test exporting an empty SELECT result set to JSON."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query("SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+                        export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "empty_results.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_export_empty_results_csv():
+    """Test exporting an empty SELECT result set to CSV still creates a valid file."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query("SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+                        export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "empty_results.csv"
+
+    assert results == []
+    assert exported_path.exists()
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        content = f.read()
+
+    # For empty results, current implementation writes just an empty file.
+    assert not content.strip()
+
+
+def test_query_rejects_non_select_query():
+    """Test that query() rejects non-SELECT SPARQL queries."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"ASK WHERE {{ GRAPH <{config['graph']}> {{ ?s ?p ?o }} }}")
+
+
+def test_query_rejects_unsupported_export_format():
+    """Test that query() rejects unsupported export formats for SELECT queries."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename="bad_output")
+
+
+def test_query_no_export_does_not_create_file():
+    """Test that query() does not create any file when export=False."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "should_not_exist.json"
+    results = store.query(SPARQL_QUERY, export=False, output_format="json", filename=str(output_file))
+
+    assert len(results) == 1
+    assert not output_file.exists()
+
+
+def test_query_accepts_prefixed_select_with_export():
+    """Test that query() correctly detects SELECT when PREFIX declarations precede it."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    sparql = f"""
+        PREFIX ex: <http://example.org/>
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    output_file = TEST_FILES_DIR / "prefixed"
+    results = store.query(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "prefixed.json"
+
+    assert exported_path.exists()
+    assert len(results) == 1
+    assert results[0]["s"] == SUBJECT
+    assert results[0]["p"] == PREDICATE
+    assert results[0]["o"] == OBJECT
+
+
+def test_execute_export_select_json():
+    """Test that execute() exports SELECT results to JSON correctly."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_json"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+    assert data[0]["s"] == SUBJECT
+    assert data[0]["p"] == PREDICATE
+    assert data[0]["o"] == OBJECT
+
+
+def test_execute_export_select_csv():
+    """Test that execute() exports SELECT results to CSV correctly."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_csv"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_execute_export_ask_json():
+    """Test that execute() exports ASK results to JSON correctly."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_json"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt():
+    """Test that execute() exports ASK results to TXT correctly."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_txt"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl():
+    """Test that execute() exports CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+    assert PREDICATE in content
+    assert OBJECT in content
+
+
+def test_execute_export_describe_ttl():
+    """Test that execute() exports DESCRIBE results to Turtle correctly."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_export_uses_default_format_for_ask():
+    """Test that execute() uses the default export format for ASK when output_format is omitted."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_default"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_default.json"
+
+    assert result is True
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_uses_default_format_for_construct():
+    """Test that execute() uses the default export format for CONSTRUCT when output_format is omitted."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct_default"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct_default.ttl"
+
+    assert isinstance(result, str)
+    assert exported_path.exists()
+    assert exported_path.read_text(encoding="utf-8").splitlines() == result.splitlines()
+
+
+def test_execute_rejects_unsupported_export_format_for_ask():
+    """Test that execute() rejects unsupported export formats for ASK queries."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_ask"))
+
+
+def test_execute_rejects_export_for_update_operations():
+    """Test that execute() rejects export for SPARQL update operations."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_update"))

--- a/triplestore/tests/test_allegrograph.py
+++ b/triplestore/tests/test_allegrograph.py
@@ -258,6 +258,41 @@ def test_load_from_turtle_file():
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
 
 
+def test_load_from_ntriples_file():
+    """Test loading triples from a .nt file into the store."""
+    ntriples_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".nt", encoding="utf-8") as f:
+        f.write(ntriples_data)
+        tmp_path = f.name
+
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_load_rejects_unsupported_file_format():
+    """Test that load() rejects unsupported RDF file formats."""
+    invalid_data = "this is not rdf"
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(invalid_data)
+        tmp_path = f.name
+
+    store = Triplestore("allegrograph", config=config)
+
+    with pytest.raises(ValueError, match="Unsupported RDF file format"):
+        store.load(tmp_path)
+
+    Path(tmp_path).unlink()
+
+
 def test_clear():
     """Test that clear() removes all triples from the store."""
     store = Triplestore("allegrograph", config=config)

--- a/triplestore/tests/test_blazegraph.py
+++ b/triplestore/tests/test_blazegraph.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import pytest
 import requests
-
 from triplestore import Triplestore
 
 SUBJECT = "http://example.org/s"
@@ -242,3 +241,52 @@ def test_execute():
     clr_out = store.execute(q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_select_star():
+    """Test SELECT *: verifies correct binding, completeness, and result integrity."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    # Insert multiple triples
+    triples = [
+        ("http://example.org/s1", "http://example.org/p1", "http://example.org/o1"),
+        ("http://example.org/s2", "http://example.org/p2", "http://example.org/o2"),
+        ("http://example.org/s3", "http://example.org/p3", "http://example.org/o3"),
+    ]
+
+    for s, p, o in triples:
+        store.add(s, p, o)
+
+    # SELECT * query
+    results = store.query(
+        f"""
+        SELECT * WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    # Check number of results
+    assert len(results) == len(triples)
+
+    expected_rows = [{"s": s, "p": p, "o": o} for s, p, o in triples]
+
+    # Check that all variables are present in each row
+    for row in results:
+        assert set(row.keys()) == {"s", "p", "o"}
+
+    # Check that all values are valid (strings and not None)
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Check exact match between expected and actual results (order-independent)
+    assert {tuple(sorted(r.items())) for r in results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # Ensure no duplicate rows are returned
+    assert len(results) == len({tuple(sorted(r.items())) for r in results})

--- a/triplestore/tests/test_blazegraph.py
+++ b/triplestore/tests/test_blazegraph.py
@@ -125,6 +125,133 @@ def test_query_roundtrip_add():
     assert count == 1
 
 
+def test_add_delete_with_literal_object():
+    """Test add()/delete() with a plain string literal object."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    s = "http://example.org/person1"
+    p = "http://example.org/name"
+    o = "Alice"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Alice"
+
+    store.delete(s, p, o)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+    assert results_after_delete == []
+
+
+def test_add_delete_with_typed_and_lang_literals():
+    """Test add()/delete() with typed and language-tagged literal objects."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    s1 = "http://example.org/person2"
+    p1 = "http://example.org/age"
+    o1 = 25
+
+    s2 = "http://example.org/person3"
+    p2 = "http://example.org/label"
+    o2 = {"value": "hallo", "lang": "de"}
+
+    store.add(s1, p1, o1)
+    store.add(s2, p2, o2)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results)
+    assert any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results)
+
+    store.delete(s1, p1, o1)
+    store.delete(s2, p2, o2)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert not any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results_after_delete)
+    assert not any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results_after_delete)
+
+
+def test_add_delete_with_blank_node_subject():
+    """Test add()/delete() with a blank node as subject."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    s = "_:b1"
+    p = "http://example.org/name"
+    o = "Anonymous"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Anonymous"
+
+    with pytest.raises(ValueError, match="Cannot delete triples using a blank node as subject."):
+        store.delete(s, p, o)
+
+
+def test_add_rejects_invalid_rdf_positions():
+    """Test that add() rejects literals as subjects and non-IRI predicates."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="subject of an RDF triple cannot be a literal"):
+        store.add("Alice", "http://example.org/name", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "_:p1", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "name", "Bob")
+
+
 def test_query_returns_empty_when_no_match():
     """Test that a SPARQL query returns no results when no match exists."""
     store = Triplestore("blazegraph", config=config)

--- a/triplestore/tests/test_blazegraph.py
+++ b/triplestore/tests/test_blazegraph.py
@@ -8,6 +8,8 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local Blazegraph instance with REST API access.
 """
 
+import csv
+import json
 import tempfile
 import time
 from pathlib import Path
@@ -20,6 +22,9 @@ SUBJECT = "http://example.org/s"
 PREDICATE = "http://example.org/p"
 OBJECT = "http://example.org/o"
 SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p ?o } }"
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 config = {
     "base_url": "http://172.27.148.51:9999/blazegraph",
@@ -290,3 +295,519 @@ def test_select_star():
 
     # Ensure no duplicate rows are returned
     assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
+def test_query_export_json():
+    """Test that query() exports SELECT results to a JSON file correctly."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "blazegraph_results1"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "blazegraph_results1.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data == results
+
+    row = data[0]
+    assert row["s"] == SUBJECT
+    assert row["p"] == PREDICATE
+    assert row["o"] == OBJECT
+
+
+def test_query_export_csv():
+    """Test that query() exports SELECT results to a CSV file correctly."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "blazegraph_results2"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "blazegraph_results2.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_export_csv_with_custom_separator():
+    """Test that query() exports SELECT results to CSV using a custom separator."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "custom_separator"
+    results = store.query(
+        SPARQL_QUERY,
+        export=True,
+        output_format="csv",
+        filename=str(output_file),
+        separator=";",
+    )
+
+    exported_path = TEST_FILES_DIR / "custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    content = exported_path.read_text()
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_query_export_json_with_existing_extension():
+    """Test that query() respects an already-correct filename extension."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "already_json.json"
+    store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    assert output_file.exists()
+    assert not (TEST_FILES_DIR / "already_json.json.json").exists()
+
+
+def test_query_export_replaces_wrong_extension():
+    """Test that query() replaces a wrong filename extension with the requested one."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "results.txt"
+    store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    assert not output_file.exists()
+    assert (TEST_FILES_DIR / "results.csv").exists()
+
+
+def test_query_export_empty_results_json():
+    """Test exporting an empty SELECT result set to JSON."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        "SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+        export=True,
+        output_format="json",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_export_empty_results_csv():
+    """Test exporting an empty SELECT result set to CSV still creates a valid file."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        "SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+        export=True,
+        output_format="csv",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.csv"
+
+    assert results == []
+    assert exported_path.exists()
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        content = f.read()
+
+    assert not content.strip()
+
+
+def test_query_rejects_non_select_query():
+    """Test that query() rejects non-SELECT SPARQL queries."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"ASK WHERE {{ GRAPH <{config['graph']}> {{ ?s ?p ?o }} }}")
+
+
+def test_query_rejects_unsupported_export_format():
+    """Test that query() rejects unsupported export formats for SELECT queries."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename="bad_output")
+
+
+def test_query_no_export_does_not_create_file():
+    """Test that query() does not create any file when export=False."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "should_not_exist.json"
+    results = store.query(SPARQL_QUERY, export=False, output_format="json", filename=str(output_file))
+
+    assert len(results) == 1
+    assert not output_file.exists()
+
+
+def test_query_accepts_prefixed_select_with_export():
+    """Test that query() correctly detects SELECT when PREFIX declarations precede it."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    sparql = f"""
+        PREFIX ex: <http://example.org/>
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    output_file = TEST_FILES_DIR / "prefixed"
+    results = store.query(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "prefixed.json"
+
+    assert exported_path.exists()
+    assert len(results) == 1
+    assert results[0]["s"] == SUBJECT
+    assert results[0]["p"] == PREDICATE
+    assert results[0]["o"] == OBJECT
+
+
+def test_execute_export_select_json():
+    """Test that execute() exports SELECT results to JSON correctly."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_json"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+    assert data[0]["s"] == SUBJECT
+    assert data[0]["p"] == PREDICATE
+    assert data[0]["o"] == OBJECT
+
+
+def test_execute_export_select_csv():
+    """Test that execute() exports SELECT results to CSV correctly."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_csv"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_execute_export_ask_json():
+    """Test that execute() exports ASK results to JSON correctly."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_json"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt():
+    """Test that execute() exports ASK results to TXT correctly."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_txt"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl():
+    """Test that execute() exports CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+    assert PREDICATE in content
+    assert OBJECT in content
+
+
+def test_execute_export_describe_ttl():
+    """Test that execute() exports DESCRIBE results to Turtle correctly."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_export_uses_default_format_for_ask():
+    """Test that execute() uses the default export format for ASK when output_format is omitted."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_default"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_default.json"
+
+    assert result is True
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_uses_default_format_for_construct():
+    """Test that execute() uses the default export format for CONSTRUCT when output_format is omitted."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct_default"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct_default.ttl"
+
+    assert isinstance(result, str)
+    assert exported_path.exists()
+    assert exported_path.read_text(encoding="utf-8").splitlines() == result.splitlines()
+
+
+def test_execute_rejects_unsupported_export_format_for_ask():
+    """Test that execute() rejects unsupported export formats for ASK queries."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_ask"))
+
+
+def test_execute_rejects_export_for_update_operations():
+    """Test that execute() rejects export for SPARQL update operations."""
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_update"))

--- a/triplestore/tests/test_blazegraph.py
+++ b/triplestore/tests/test_blazegraph.py
@@ -281,6 +281,41 @@ def test_load_from_turtle_file():
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
 
 
+def test_load_from_ntriples_file():
+    """Test loading triples from a .nt file into the store."""
+    ntriples_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".nt", encoding="utf-8") as f:
+        f.write(ntriples_data)
+        tmp_path = f.name
+
+    store = Triplestore("blazegraph", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_load_rejects_unsupported_file_format():
+    """Test that load() rejects unsupported RDF file formats."""
+    invalid_data = "this is not rdf"
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(invalid_data)
+        tmp_path = f.name
+
+    store = Triplestore("blazegraph", config=config)
+
+    with pytest.raises(ValueError, match="Unsupported RDF file format"):
+        store.load(tmp_path)
+
+    Path(tmp_path).unlink()
+
+
 def test_clear():
     """Test that clear() removes all triples from the store."""
     store = Triplestore("blazegraph", config=config)

--- a/triplestore/tests/test_graphdb.py
+++ b/triplestore/tests/test_graphdb.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import pytest
 import requests
-
 from triplestore import Triplestore
 from triplestore.utils import detect_graphdb_url
 
@@ -244,3 +243,52 @@ def test_execute():
     clr_out = store.execute(q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_select_star():
+    """Test SELECT *: verifies correct binding, completeness, and result integrity."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    # Insert multiple triples
+    triples = [
+        ("http://example.org/s1", "http://example.org/p1", "http://example.org/o1"),
+        ("http://example.org/s2", "http://example.org/p2", "http://example.org/o2"),
+        ("http://example.org/s3", "http://example.org/p3", "http://example.org/o3"),
+    ]
+
+    for s, p, o in triples:
+        store.add(s, p, o)
+
+    # SELECT * query
+    results = store.query(
+        f"""
+        SELECT * WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    # Check number of results
+    assert len(results) == len(triples)
+
+    expected_rows = [{"s": s, "p": p, "o": o} for s, p, o in triples]
+
+    # Check that all variables are present in each row
+    for row in results:
+        assert set(row.keys()) == {"s", "p", "o"}
+
+    # Check that all values are valid (strings and not None)
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Check exact match between expected and actual results (order-independent)
+    assert {tuple(sorted(r.items())) for r in results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # Ensure no duplicate rows are returned
+    assert len(results) == len({tuple(sorted(r.items())) for r in results})

--- a/triplestore/tests/test_graphdb.py
+++ b/triplestore/tests/test_graphdb.py
@@ -8,6 +8,8 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local GraphDB instance with REST API access.
 """
 
+import csv
+import json
 import tempfile
 import time
 from pathlib import Path
@@ -21,6 +23,9 @@ SUBJECT = "http://example.org/s"
 PREDICATE = "http://example.org/p"
 OBJECT = "http://example.org/o"
 SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p ?o } }"
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 def is_graphdb_available():
@@ -292,3 +297,506 @@ def test_select_star():
 
     # Ensure no duplicate rows are returned
     assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
+def test_query_export_json():
+    """Test that query() exports SELECT results to a JSON file correctly."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "graphdb_results1"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_results1.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data == results
+
+    row = data[0]
+    assert row["s"] == SUBJECT
+    assert row["p"] == PREDICATE
+    assert row["o"] == OBJECT
+
+
+def test_query_export_csv():
+    """Test that query() exports SELECT results to a CSV file correctly."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "graphdb_results2"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_results2.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_export_csv_with_custom_separator():
+    """Test that query() exports SELECT results to CSV using a custom separator."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    # Check raw file content for separator
+    content = exported_path.read_text()
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+def test_query_export_json_with_existing_extension():
+    """Test that query() respects an already-correct filename extension."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "already_json.json"
+    store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    assert output_file.exists()
+    assert not (TEST_FILES_DIR / "already_json.json.json").exists()
+
+
+def test_query_export_replaces_wrong_extension():
+    """Test that query() replaces a wrong filename extension with the requested one."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "results.txt"
+    store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    assert not output_file.exists()
+    assert (TEST_FILES_DIR / "results.csv").exists()
+
+
+def test_query_export_empty_results_json():
+    """Test exporting an empty SELECT result set to JSON."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query("SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+                        export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "empty_results.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_export_empty_results_csv():
+    """Test exporting an empty SELECT result set to CSV still creates a valid file."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query("SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+                        export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "empty_results.csv"
+
+    assert results == []
+    assert exported_path.exists()
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        content = f.read()
+
+    # For empty results, current implementation writes just an empty file.
+    assert not content.strip()
+
+
+def test_query_rejects_non_select_query():
+    """Test that query() rejects non-SELECT SPARQL queries."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"ASK WHERE {{ GRAPH <{config['graph']}> {{ ?s ?p ?o }} }}")
+
+
+def test_query_rejects_unsupported_export_format():
+    """Test that query() rejects unsupported export formats for SELECT queries."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename="bad_output")
+
+
+def test_query_no_export_does_not_create_file():
+    """Test that query() does not create any file when export=False."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "should_not_exist.json"
+    results = store.query(SPARQL_QUERY, export=False, output_format="json", filename=str(output_file))
+
+    assert len(results) == 1
+    assert not output_file.exists()
+
+
+def test_query_accepts_prefixed_select_with_export():
+    """Test that query() correctly detects SELECT when PREFIX declarations precede it."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    sparql = f"""
+        PREFIX ex: <http://example.org/>
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    output_file = TEST_FILES_DIR / "prefixed"
+    results = store.query(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "prefixed.json"
+
+    assert exported_path.exists()
+    assert len(results) == 1
+    assert results[0]["s"] == SUBJECT
+    assert results[0]["p"] == PREDICATE
+    assert results[0]["o"] == OBJECT
+
+
+def test_execute_export_select_json():
+    """Test that execute() exports SELECT results to JSON correctly."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_json"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+    assert data[0]["s"] == SUBJECT
+    assert data[0]["p"] == PREDICATE
+    assert data[0]["o"] == OBJECT
+
+
+def test_execute_export_select_csv():
+    """Test that execute() exports SELECT results to CSV correctly."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_csv"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_execute_export_ask_json():
+    """Test that execute() exports ASK results to JSON correctly."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_json"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt():
+    """Test that execute() exports ASK results to TXT correctly."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_txt"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl():
+    """Test that execute() exports CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+    assert PREDICATE in content
+    assert OBJECT in content
+
+
+def test_execute_export_describe_ttl():
+    """Test that execute() exports DESCRIBE results to Turtle correctly."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_export_uses_default_format_for_ask():
+    """Test that execute() uses the default export format for ASK when output_format is omitted."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_default"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_default.json"
+
+    assert result is True
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_uses_default_format_for_construct():
+    """Test that execute() uses the default export format for CONSTRUCT when output_format is omitted."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct_default"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct_default.ttl"
+
+    assert isinstance(result, str)
+    assert exported_path.exists()
+    assert exported_path.read_text(encoding="utf-8").splitlines() == result.splitlines()
+
+
+def test_execute_rejects_unsupported_export_format_for_ask():
+    """Test that execute() rejects unsupported export formats for ASK queries."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_ask"))
+
+
+def test_execute_rejects_export_for_update_operations():
+    """Test that execute() rejects export for SPARQL update operations."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_update"))

--- a/triplestore/tests/test_graphdb.py
+++ b/triplestore/tests/test_graphdb.py
@@ -129,6 +129,133 @@ def test_query_roundtrip_add():
     assert count == 1
 
 
+def test_add_delete_with_literal_object():
+    """Test add()/delete() with a plain string literal object."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    s = "http://example.org/person1"
+    p = "http://example.org/name"
+    o = "Alice"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Alice"
+
+    store.delete(s, p, o)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+    assert results_after_delete == []
+
+
+def test_add_delete_with_typed_and_lang_literals():
+    """Test add()/delete() with typed and language-tagged literal objects."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    s1 = "http://example.org/person2"
+    p1 = "http://example.org/age"
+    o1 = 25
+
+    s2 = "http://example.org/person3"
+    p2 = "http://example.org/label"
+    o2 = {"value": "hallo", "lang": "de"}
+
+    store.add(s1, p1, o1)
+    store.add(s2, p2, o2)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results)
+    assert any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results)
+
+    store.delete(s1, p1, o1)
+    store.delete(s2, p2, o2)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert not any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results_after_delete)
+    assert not any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results_after_delete)
+
+
+def test_add_delete_with_blank_node_subject():
+    """Test add()/delete() with a blank node as subject."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    s = "_:b1"
+    p = "http://example.org/name"
+    o = "Anonymous"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Anonymous"
+
+    with pytest.raises(ValueError, match="Cannot delete triples using a blank node as subject."):
+        store.delete(s, p, o)
+
+
+def test_add_rejects_invalid_rdf_positions():
+    """Test that add() rejects literals as subjects and non-IRI predicates."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="subject of an RDF triple cannot be a literal"):
+        store.add("Alice", "http://example.org/name", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "_:p1", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "name", "Bob")
+
+
 def test_query_returns_empty_when_no_match():
     """Test that a SPARQL query returns no results when no match exists."""
     store = Triplestore("graphdb", config=config)

--- a/triplestore/tests/test_graphdb.py
+++ b/triplestore/tests/test_graphdb.py
@@ -27,8 +27,6 @@ SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p 
 TEST_FILES_DIR = Path(__file__).parent / "tests_files"
 TEST_FILES_DIR.mkdir(exist_ok=True)
 
-BULK_FILE = "data_20k_triples.ttl"
-
 
 def is_graphdb_available():
     try:
@@ -283,75 +281,6 @@ def test_load_from_turtle_file():
 
     bindings = [str(binding) for binding in results]
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
-
-
-def test_bulk_load_uses_instance_graph():
-    """Test that bulk_load() imports data into the graph configured on the backend instance."""
-    store = Triplestore("graphdb", config=config)
-    store.clear()
-
-    try:
-        store.bulk_load(BULK_FILE)
-    except RuntimeError as e:
-        pytest.skip(
-            f"Skipping bulk_load test: server file '{BULK_FILE}' is not available "
-            f"or import failed ({e})."
-        )
-
-    deadline = time.time() + 600
-
-    while time.time() < deadline:
-        results = store.query(SPARQL_QUERY)
-        if results:
-            assert isinstance(results, list)
-            assert len(results) > 0
-            return
-        time.sleep(1.0)
-
-    pytest.fail(
-        f"[GraphDB] bulk_load() did not populate graph <{config['graph']}> "
-        f"within 600 seconds."
-    )
-
-
-def test_bulk_load_target_graph_overrides_instance_graph():
-    """Test that bulk_load() uses target_graph instead of the configured instance graph."""
-    store = Triplestore("graphdb", config=config)
-    store.clear()
-
-    override_graph = "http://example.org/bulk-override"
-    store.execute(f"CLEAR GRAPH <{override_graph}>")
-
-    try:
-        store.bulk_load(BULK_FILE, target_graph=override_graph)
-    except RuntimeError as e:
-        pytest.skip(
-            f"Skipping bulk_load override test: server file '{BULK_FILE}' is not available "
-            f"or import failed ({e})."
-        )
-
-    deadline = time.time() + 600
-
-    while time.time() < deadline:
-        results = store.query(
-            f"SELECT ?s ?p ?o WHERE {{ GRAPH <{override_graph}> {{ ?s ?p ?o }} }} LIMIT 1"
-        )
-        if results:
-            assert isinstance(results, list)
-            assert len(results) > 0
-            break
-        time.sleep(1.0)
-    else:
-        pytest.fail(
-            f"[GraphDB] bulk_load() did not populate override graph <{override_graph}> "
-            f"within 600 seconds."
-        )
-
-    # Ensure nothing leaked into default graph
-    default_graph_results = store.query(SPARQL_QUERY)
-    assert default_graph_results == []
-
-    store.execute(f"CLEAR GRAPH <{override_graph}>")
 
 
 def test_clear():

--- a/triplestore/tests/test_graphdb.py
+++ b/triplestore/tests/test_graphdb.py
@@ -27,6 +27,8 @@ SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p 
 TEST_FILES_DIR = Path(__file__).parent / "tests_files"
 TEST_FILES_DIR.mkdir(exist_ok=True)
 
+BULK_FILE = "data_20k_triples.ttl"
+
 
 def is_graphdb_available():
     try:
@@ -154,6 +156,75 @@ def test_load_from_turtle_file():
 
     bindings = [str(binding) for binding in results]
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_bulk_load_uses_instance_graph():
+    """Test that bulk_load() imports data into the graph configured on the backend instance."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    try:
+        store.bulk_load(BULK_FILE)
+    except RuntimeError as e:
+        pytest.skip(
+            f"Skipping bulk_load test: server file '{BULK_FILE}' is not available "
+            f"or import failed ({e})."
+        )
+
+    deadline = time.time() + 600
+
+    while time.time() < deadline:
+        results = store.query(SPARQL_QUERY)
+        if results:
+            assert isinstance(results, list)
+            assert len(results) > 0
+            return
+        time.sleep(1.0)
+
+    pytest.fail(
+        f"[GraphDB] bulk_load() did not populate graph <{config['graph']}> "
+        f"within 600 seconds."
+    )
+
+
+def test_bulk_load_target_graph_overrides_instance_graph():
+    """Test that bulk_load() uses target_graph instead of the configured instance graph."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    override_graph = "http://example.org/bulk-override"
+    store.execute(f"CLEAR GRAPH <{override_graph}>")
+
+    try:
+        store.bulk_load(BULK_FILE, target_graph=override_graph)
+    except RuntimeError as e:
+        pytest.skip(
+            f"Skipping bulk_load override test: server file '{BULK_FILE}' is not available "
+            f"or import failed ({e})."
+        )
+
+    deadline = time.time() + 600
+
+    while time.time() < deadline:
+        results = store.query(
+            f"SELECT ?s ?p ?o WHERE {{ GRAPH <{override_graph}> {{ ?s ?p ?o }} }} LIMIT 1"
+        )
+        if results:
+            assert isinstance(results, list)
+            assert len(results) > 0
+            break
+        time.sleep(1.0)
+    else:
+        pytest.fail(
+            f"[GraphDB] bulk_load() did not populate override graph <{override_graph}> "
+            f"within 600 seconds."
+        )
+
+    # Ensure nothing leaked into default graph
+    default_graph_results = store.query(SPARQL_QUERY)
+    assert default_graph_results == []
+
+    store.execute(f"CLEAR GRAPH <{override_graph}>")
 
 
 def test_clear():
@@ -380,6 +451,7 @@ def test_export_csv_with_custom_separator():
     assert rows[0]["s"] == SUBJECT
     assert rows[0]["p"] == PREDICATE
     assert rows[0]["o"] == OBJECT
+
 
 def test_query_export_json_with_existing_extension():
     """Test that query() respects an already-correct filename extension."""

--- a/triplestore/tests/test_graphdb.py
+++ b/triplestore/tests/test_graphdb.py
@@ -283,6 +283,41 @@ def test_load_from_turtle_file():
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
 
 
+def test_load_from_ntriples_file():
+    """Test loading triples from a .nt file into the store."""
+    ntriples_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".nt", encoding="utf-8") as f:
+        f.write(ntriples_data)
+        tmp_path = f.name
+
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_load_rejects_unsupported_file_format():
+    """Test that load() rejects unsupported RDF file formats."""
+    invalid_data = "this is not rdf"
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(invalid_data)
+        tmp_path = f.name
+
+    store = Triplestore("graphdb", config=config)
+
+    with pytest.raises(ValueError, match="Unsupported RDF file format"):
+        store.load(tmp_path)
+
+    Path(tmp_path).unlink()
+
+
 def test_clear():
     """Test that clear() removes all triples from the store."""
     store = Triplestore("graphdb", config=config)

--- a/triplestore/tests/test_graphdb_offline.py
+++ b/triplestore/tests/test_graphdb_offline.py
@@ -1,0 +1,208 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the offline bulk loading of the GraphDB backend.
+
+These tests use the GraphDB ImportRDF tool, so the server must be stopped
+before import and started again afterwards.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from triplestore import Triplestore
+from triplestore.utils import detect_graphdb_url
+
+BULK_SUBJECT = "http://example.org/bulk_s"
+BULK_PREDICATE = "http://example.org/bulk_p"
+BULK_OBJECT = "http://example.org/bulk_o"
+
+GRAPHDB_BASE_URL = detect_graphdb_url()
+
+GRAPHDB_HOME_ENV = os.environ.get("GRAPHDB_HOME")
+GRAPHDB_HOME = Path(GRAPHDB_HOME_ENV).expanduser().resolve() if GRAPHDB_HOME_ENV else None
+GRAPHDB_BIN = GRAPHDB_HOME / "bin" / "graphdb" if GRAPHDB_HOME else Path("/invalid/path")
+
+config = {
+    "name": f"testns-bulk-{int(time.time())}",
+}
+
+
+pytestmark = pytest.mark.skipif(
+    not GRAPHDB_HOME or not GRAPHDB_BIN.exists(),
+    reason=(
+        "[GraphDB] Skipped because GraphDB is not properly configured.\n"
+        "Expected environment variable GRAPHDB_HOME pointing to a valid installation.\n"
+        "Required executable not found: $GRAPHDB_HOME/bin/graphdb"
+    ),
+)
+
+
+def is_graphdb_available():
+    """Return True if the GraphDB HTTP endpoint is reachable."""
+    try:
+        response = requests.get(f"{GRAPHDB_BASE_URL}/repositories", timeout=2)
+    except requests.RequestException:
+        return False
+    else:
+        return response.status_code in {200, 401, 403}
+
+
+def wait_until_graphdb_is_up(timeout: int = 60) -> None:
+    """Wait until GraphDB becomes reachable."""
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if is_graphdb_available():
+            return
+        time.sleep(1)
+
+    msg = "GraphDB did not start in time."
+    raise RuntimeError(msg)
+
+
+def wait_until_graphdb_is_down(timeout: int = 30) -> None:
+    """Wait until GraphDB becomes unreachable."""
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        if not is_graphdb_available():
+            return
+        time.sleep(1)
+
+    msg = "GraphDB did not stop in time."
+    raise RuntimeError(msg)
+
+
+def start_graphdb_server() -> None:
+    """Start the local GraphDB server using GRAPHDB_HOME/bin/graphdb."""
+    if is_graphdb_available():
+        return
+
+    subprocess.Popen([str(GRAPHDB_BIN)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True, start_new_session=True)
+    wait_until_graphdb_is_up()
+
+
+def _find_graphdb_pids() -> list[int]:
+    """Return the PIDs of processes listening on port 7200."""
+    try:
+        result = subprocess.run(["lsof", "-ti", ":7200"], check=False, capture_output=True, text=True)
+    except FileNotFoundError as err:
+        msg = "lsof is not available on this system."
+        raise RuntimeError(msg) from err
+
+    if result.returncode not in {0, 1}:
+        msg = f"lsof failed: {result.stderr.strip()}"
+        raise RuntimeError(msg)
+
+    if result.returncode == 1 or not result.stdout.strip():
+        return []
+
+    return [int(pid) for pid in result.stdout.split()]
+
+
+def stop_graphdb_server() -> None:
+    """Stop the local GraphDB server."""
+    pids = _find_graphdb_pids()
+
+    if not pids:
+        if not is_graphdb_available():
+            return
+        msg = "GraphDB is reachable, but no process listening on port 7200 was found."
+        raise RuntimeError(msg)
+
+    for pid in pids:
+        subprocess.run(["kill", "-TERM", str(pid)], check=False)
+    wait_until_graphdb_is_down()
+
+
+def create_bulk_turtle_file() -> str:
+    """Create a temporary Turtle file for bulk_load() tests."""
+    turtle_data = f"<{BULK_SUBJECT}> <{BULK_PREDICATE}> <{BULK_OBJECT}> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        return f.name
+
+
+def ask_bulk_triple(store: Triplestore) -> bool:
+    """Return True if the expected triple exists in the store."""
+    return store.execute(
+        f"""
+        ASK {{
+            <{BULK_SUBJECT}> <{BULK_PREDICATE}> <{BULK_OBJECT}>
+        }}
+        """
+    )
+
+
+def test_bulk_load_rejects_invalid_mode():
+    """Test that bulk_load() rejects unsupported mode values."""
+    store = Triplestore("graphdb", config=config)
+
+    with pytest.raises(ValueError, match="Supported modes are 'load' and 'preload'"):
+        store.bulk_load("dummy.ttl", mode="invalid")
+
+
+def test_bulk_load_rejects_empty_input():
+    """Test that bulk_load() rejects empty input paths."""
+    store = Triplestore("graphdb", config=config)
+
+    with pytest.raises(ValueError, match="received no input paths"):
+        store.bulk_load([], mode="load")
+
+
+def test_bulk_load_rejects_missing_file():
+    """Test that bulk_load() raises FileNotFoundError for a missing input path."""
+    store = Triplestore("graphdb", config=config)
+
+    with pytest.raises(FileNotFoundError, match="could not find the input path"):
+        store.bulk_load("does_not_exist.ttl", mode="load")
+
+
+def test_bulk_load_mode_load():
+    """Test that bulk_load() in 'load' mode imports data correctly."""
+    start_graphdb_server()
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    tmp_path = create_bulk_turtle_file()
+
+    try:
+        stop_graphdb_server()
+        store.bulk_load(tmp_path, mode="load")
+        start_graphdb_server()
+        assert ask_bulk_triple(store) is True
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+        if is_graphdb_available():
+            store.clear()
+            stop_graphdb_server()
+
+
+def test_bulk_load_mode_preload():
+    """Test that bulk_load() in 'preload' mode imports data correctly."""
+    start_graphdb_server()
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    tmp_path = create_bulk_turtle_file()
+
+    try:
+        stop_graphdb_server()
+        store.bulk_load(tmp_path, mode="preload")
+        start_graphdb_server()
+        assert ask_bulk_triple(store) is True
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+        if is_graphdb_available():
+            store.clear()
+            stop_graphdb_server()

--- a/triplestore/tests/test_jena.py
+++ b/triplestore/tests/test_jena.py
@@ -117,6 +117,133 @@ def test_query_roundtrip_add():
     assert count == 1
 
 
+def test_add_delete_with_literal_object():
+    """Test add()/delete() with a plain string literal object."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    s = "http://example.org/person1"
+    p = "http://example.org/name"
+    o = "Alice"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Alice"
+
+    store.delete(s, p, o)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+    assert results_after_delete == []
+
+
+def test_add_delete_with_typed_and_lang_literals():
+    """Test add()/delete() with typed and language-tagged literal objects."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    s1 = "http://example.org/person2"
+    p1 = "http://example.org/age"
+    o1 = 25
+
+    s2 = "http://example.org/person3"
+    p2 = "http://example.org/label"
+    o2 = {"value": "hallo", "lang": "de"}
+
+    store.add(s1, p1, o1)
+    store.add(s2, p2, o2)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results)
+    assert any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results)
+
+    store.delete(s1, p1, o1)
+    store.delete(s2, p2, o2)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert not any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results_after_delete)
+    assert not any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results_after_delete)
+
+
+def test_add_delete_with_blank_node_subject():
+    """Test add()/delete() with a blank node as subject."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    s = "_:b1"
+    p = "http://example.org/name"
+    o = "Anonymous"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Anonymous"
+
+    with pytest.raises(ValueError, match="Cannot delete triples using a blank node as subject."):
+        store.delete(s, p, o)
+
+
+def test_add_rejects_invalid_rdf_positions():
+    """Test that add() rejects literals as subjects and non-IRI predicates."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="subject of an RDF triple cannot be a literal"):
+        store.add("Alice", "http://example.org/name", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "_:p1", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "name", "Bob")
+
+
 def test_query_returns_empty_when_no_match():
     """Test that a SPARQL query returns no results when no match exists."""
     store = Triplestore("jena", config=config)

--- a/triplestore/tests/test_jena.py
+++ b/triplestore/tests/test_jena.py
@@ -8,10 +8,13 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local Jena Fuseki instance with REST API access.
 """
 
+import csv
+import json
 import tempfile
 import time
 from pathlib import Path
 
+import pytest
 import requests
 from triplestore import Triplestore
 
@@ -19,6 +22,9 @@ SUBJECT = "http://example.org/s"
 PREDICATE = "http://example.org/p"
 OBJECT = "http://example.org/o"
 SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p ?o } }"
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 config = {
@@ -282,6 +288,516 @@ def test_select_star():
 
     # Ensure no duplicate rows are returned
     assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
+def test_query_export_json():
+    """Test that query() exports SELECT results to a JSON file correctly."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "jena_results1"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_results1.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data == results
+
+    row = data[0]
+    assert row["s"] == SUBJECT
+    assert row["p"] == PREDICATE
+    assert row["o"] == OBJECT
+
+
+def test_query_export_csv():
+    """Test that query() exports SELECT results to a CSV file correctly."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "jena_results2"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_results2.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_export_csv_with_custom_separator():
+    """Test that query() exports SELECT results to CSV using a custom separator."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    content = exported_path.read_text()
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_query_export_json_with_existing_extension():
+    """Test that query() respects an already-correct filename extension."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "already_json.json"
+    store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    assert output_file.exists()
+    assert not (TEST_FILES_DIR / "already_json.json.json").exists()
+
+
+def test_query_export_replaces_wrong_extension():
+    """Test that query() replaces a wrong filename extension with the requested one."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "results.txt"
+    store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    assert not output_file.exists()
+    assert (TEST_FILES_DIR / "results.csv").exists()
+
+
+def test_query_export_empty_results_json():
+    """Test exporting an empty SELECT result set to JSON."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        "SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+        export=True,
+        output_format="json",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_export_empty_results_csv():
+    """Test exporting an empty SELECT result set to CSV still creates a valid file."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        "SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+        export=True,
+        output_format="csv",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.csv"
+
+    assert results == []
+    assert exported_path.exists()
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        content = f.read()
+
+    assert not content.strip()
+
+
+def test_query_rejects_non_select_query():
+    """Test that query() rejects non-SELECT SPARQL queries."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"ASK WHERE {{ GRAPH <{config['graph']}> {{ ?s ?p ?o }} }}")
+
+
+def test_query_rejects_unsupported_export_format():
+    """Test that query() rejects unsupported export formats for SELECT queries."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename="bad_output")
+
+
+def test_query_no_export_does_not_create_file():
+    """Test that query() does not create any file when export=False."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "should_not_exist.json"
+    results = store.query(SPARQL_QUERY, export=False, output_format="json", filename=str(output_file))
+
+    assert len(results) == 1
+    assert not output_file.exists()
+
+
+def test_query_accepts_prefixed_select_with_export():
+    """Test that query() correctly detects SELECT when PREFIX declarations precede it."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    sparql = f"""
+        PREFIX ex: <http://example.org/>
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    output_file = TEST_FILES_DIR / "prefixed"
+    results = store.query(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "prefixed.json"
+
+    assert exported_path.exists()
+    assert len(results) == 1
+    assert results[0]["s"] == SUBJECT
+    assert results[0]["p"] == PREDICATE
+    assert results[0]["o"] == OBJECT
+
+
+def test_execute_export_select_json():
+    """Test that execute() exports SELECT results to JSON correctly."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_json"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+    assert data[0]["s"] == SUBJECT
+    assert data[0]["p"] == PREDICATE
+    assert data[0]["o"] == OBJECT
+
+
+def test_execute_export_select_csv():
+    """Test that execute() exports SELECT results to CSV correctly."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_csv"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_execute_export_ask_json():
+    """Test that execute() exports ASK results to JSON correctly."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_json"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt():
+    """Test that execute() exports ASK results to TXT correctly."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_txt"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl():
+    """Test that execute() exports CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+    assert PREDICATE in content
+    assert OBJECT in content
+
+
+def test_execute_export_describe_ttl():
+    """Test that execute() exports DESCRIBE results to Turtle correctly."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_export_uses_default_format_for_ask():
+    """Test that execute() uses the default export format for ASK when output_format is omitted."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_default"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_default.json"
+
+    assert result is True
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_uses_default_format_for_construct():
+    """Test that execute() uses the default export format for CONSTRUCT when output_format is omitted."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct_default"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct_default.ttl"
+
+    assert isinstance(result, str)
+    assert exported_path.exists()
+    assert exported_path.read_text(encoding="utf-8").splitlines() == result.splitlines()
+
+
+def test_execute_rejects_unsupported_export_format_for_ask():
+    """Test that execute() rejects unsupported export formats for ASK queries."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_ask"))
+
+
+def test_execute_rejects_export_for_update_operations():
+    """Test that execute() rejects export for SPARQL update operations."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_update"))
 
 
 def test_stop_server():

--- a/triplestore/tests/test_jena.py
+++ b/triplestore/tests/test_jena.py
@@ -13,7 +13,6 @@ import time
 from pathlib import Path
 
 import requests
-
 from triplestore import Triplestore
 
 SUBJECT = "http://example.org/s"
@@ -234,6 +233,55 @@ def test_execute():
     clr_out = store.execute(q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_select_star():
+    """Test SELECT *: verifies correct binding, completeness, and result integrity."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    # Insert multiple triples
+    triples = [
+        ("http://example.org/s1", "http://example.org/p1", "http://example.org/o1"),
+        ("http://example.org/s2", "http://example.org/p2", "http://example.org/o2"),
+        ("http://example.org/s3", "http://example.org/p3", "http://example.org/o3"),
+    ]
+
+    for s, p, o in triples:
+        store.add(s, p, o)
+
+    # SELECT * query
+    results = store.query(
+        f"""
+        SELECT * WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    # Check number of results
+    assert len(results) == len(triples)
+
+    expected_rows = [{"s": s, "p": p, "o": o} for s, p, o in triples]
+
+    # Check that all variables are present in each row
+    for row in results:
+        assert set(row.keys()) == {"s", "p", "o"}
+
+    # Check that all values are valid (strings and not None)
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Check exact match between expected and actual results (order-independent)
+    assert {tuple(sorted(r.items())) for r in results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # Ensure no duplicate rows are returned
+    assert len(results) == len({tuple(sorted(r.items())) for r in results})
 
 
 def test_stop_server():

--- a/triplestore/tests/test_jena.py
+++ b/triplestore/tests/test_jena.py
@@ -273,6 +273,41 @@ def test_load_from_turtle_file():
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
 
 
+def test_load_from_ntriples_file():
+    """Test loading triples from a .nt file into the store."""
+    ntriples_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".nt", encoding="utf-8") as f:
+        f.write(ntriples_data)
+        tmp_path = f.name
+
+    store = Triplestore("jena", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_load_rejects_unsupported_file_format():
+    """Test that load() rejects unsupported RDF file formats."""
+    invalid_data = "this is not rdf"
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(invalid_data)
+        tmp_path = f.name
+
+    store = Triplestore("jena", config=config)
+
+    with pytest.raises(ValueError, match="Unsupported RDF file format"):
+        store.load(tmp_path)
+
+    Path(tmp_path).unlink()
+
+
 def test_clear():
     """Test that clear() removes all triples from the store."""
     store = Triplestore("jena", config=config)

--- a/triplestore/tests/test_oxigraph.py
+++ b/triplestore/tests/test_oxigraph.py
@@ -219,3 +219,52 @@ def test_execute():
     clr_out = store.execute(q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_select_star():
+    """Test SELECT *: verifies correct binding, completeness, and result integrity."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    # Insert multiple triples
+    triples = [
+        ("http://example.org/s1", "http://example.org/p1", "http://example.org/o1"),
+        ("http://example.org/s2", "http://example.org/p2", "http://example.org/o2"),
+        ("http://example.org/s3", "http://example.org/p3", "http://example.org/o3"),
+    ]
+
+    for s, p, o in triples:
+        store.add(s, p, o)
+
+    # SELECT * query
+    results = store.query(
+        f"""
+        SELECT * WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    # Check number of results
+    assert len(results) == len(triples)
+
+    expected_rows = [{"s": s, "p": p, "o": o} for s, p, o in triples]
+
+    # Check that all variables are present in each row
+    for row in results:
+        assert set(row.keys()) == {"s", "p", "o"}
+
+    # Check that all values are valid (strings and not None)
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Check exact match between expected and actual results (order-independent)
+    assert {tuple(sorted(r.items())) for r in results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # Ensure no duplicate rows are returned
+    assert len(results) == len({tuple(sorted(r.items())) for r in results})

--- a/triplestore/tests/test_oxigraph.py
+++ b/triplestore/tests/test_oxigraph.py
@@ -100,6 +100,144 @@ def test_query_roundtrip_add():
     assert count == 1
 
 
+def test_add_delete_with_literal_object():
+    """Test add()/delete() with a plain string literal object."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    s = "http://example.org/person1"
+    p = "http://example.org/name"
+    o = "Alice"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Alice"
+
+    store.delete(s, p, o)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+    assert results_after_delete == []
+
+
+def test_add_delete_with_typed_and_lang_literals():
+    """Test add()/delete() with typed and language-tagged literal objects."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    s1 = "http://example.org/person2"
+    p1 = "http://example.org/age"
+    o1 = 25
+
+    s2 = "http://example.org/person3"
+    p2 = "http://example.org/label"
+    o2 = {"value": "hallo", "lang": "de"}
+
+    store.add(s1, p1, o1)
+    store.add(s2, p2, o2)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results)
+    assert any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results)
+
+    store.delete(s1, p1, o1)
+    store.delete(s2, p2, o2)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert not any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results_after_delete)
+    assert not any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results_after_delete)
+
+
+def test_add_delete_with_blank_node_subject():
+    """Test add()/delete() with a blank node as subject."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    s = "_:b1"
+    p = "http://example.org/name"
+    o = "Anonymous"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Anonymous"
+
+    store.delete(s, p, o)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?s ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert results_after_delete == []
+
+
+def test_add_rejects_invalid_rdf_positions():
+    """Test that add() rejects literals as subjects and non-IRI predicates."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="subject of an RDF triple cannot be a literal"):
+        store.add("Alice", "http://example.org/name", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "_:p1", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "name", "Bob")
+
+
 def test_query_returns_empty_when_no_match():
     """Test that a SPARQL query returns no results when no match exists."""
     store = Triplestore("oxigraph", config=config)

--- a/triplestore/tests/test_oxigraph.py
+++ b/triplestore/tests/test_oxigraph.py
@@ -1,9 +1,12 @@
 # Copyright (C) 2025 Maira Papadopoulou
 # SPDX-License-Identifier: Apache-2.0
 
+import csv
+import json
 import tempfile
 from pathlib import Path
 
+import pytest
 from triplestore import Triplestore
 
 # Sample data
@@ -11,6 +14,9 @@ SUBJECT = "http://example.org/s"
 PREDICATE = "http://example.org/p"
 OBJECT = "http://example.org/o"
 SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p ?o } }"
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 config = {
@@ -268,3 +274,516 @@ def test_select_star():
 
     # Ensure no duplicate rows are returned
     assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
+def test_query_export_json():
+    """Test that query() exports SELECT results to a JSON file correctly."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "oxigraph_results1"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "oxigraph_results1.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data == results
+
+    row = data[0]
+    assert row["s"] == SUBJECT
+    assert row["p"] == PREDICATE
+    assert row["o"] == OBJECT
+
+
+def test_query_export_csv():
+    """Test that query() exports SELECT results to a CSV file correctly."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "oxigraph_results2"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "oxigraph_results2.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_export_csv_with_custom_separator():
+    """Test that query() exports SELECT results to CSV using a custom separator."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    content = exported_path.read_text()
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_query_export_json_with_existing_extension():
+    """Test that query() respects an already-correct filename extension."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "already_json.json"
+    store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    assert output_file.exists()
+    assert not (TEST_FILES_DIR / "already_json.json.json").exists()
+
+
+def test_query_export_replaces_wrong_extension():
+    """Test that query() replaces a wrong filename extension with the requested one."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "results.txt"
+    store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    assert not output_file.exists()
+    assert (TEST_FILES_DIR / "results.csv").exists()
+
+
+def test_query_export_empty_results_json():
+    """Test exporting an empty SELECT result set to JSON."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        "SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+        export=True,
+        output_format="json",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_export_empty_results_csv():
+    """Test exporting an empty SELECT result set to CSV still creates a valid file."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        "SELECT ?s WHERE { <http://example.org/does-not-exist> ?p ?o }",
+        export=True,
+        output_format="csv",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.csv"
+
+    assert results == []
+    assert exported_path.exists()
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        content = f.read()
+
+    assert not content.strip()
+
+
+def test_query_rejects_non_select_query():
+    """Test that query() rejects non-SELECT SPARQL queries."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"ASK WHERE {{ GRAPH <{config['graph']}> {{ ?s ?p ?o }} }}")
+
+
+def test_query_rejects_unsupported_export_format():
+    """Test that query() rejects unsupported export formats for SELECT queries."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename="bad_output")
+
+
+def test_query_no_export_does_not_create_file():
+    """Test that query() does not create any file when export=False."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "should_not_exist.json"
+    results = store.query(SPARQL_QUERY, export=False, output_format="json", filename=str(output_file))
+
+    assert len(results) == 1
+    assert not output_file.exists()
+
+
+def test_query_accepts_prefixed_select_with_export():
+    """Test that query() correctly detects SELECT when PREFIX declarations precede it."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    sparql = f"""
+        PREFIX ex: <http://example.org/>
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    output_file = TEST_FILES_DIR / "prefixed"
+    results = store.query(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "prefixed.json"
+
+    assert exported_path.exists()
+    assert len(results) == 1
+    assert results[0]["s"] == SUBJECT
+    assert results[0]["p"] == PREDICATE
+    assert results[0]["o"] == OBJECT
+
+
+def test_execute_export_select_json():
+    """Test that execute() exports SELECT results to JSON correctly."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_json"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+    assert data[0]["s"] == SUBJECT
+    assert data[0]["p"] == PREDICATE
+    assert data[0]["o"] == OBJECT
+
+
+def test_execute_export_select_csv():
+    """Test that execute() exports SELECT results to CSV correctly."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_csv"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_execute_export_ask_json():
+    """Test that execute() exports ASK results to JSON correctly."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_json"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt():
+    """Test that execute() exports ASK results to TXT correctly."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_txt"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl():
+    """Test that execute() exports CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+    assert PREDICATE in content
+    assert OBJECT in content
+
+
+def test_execute_export_describe_ttl():
+    """Test that execute() exports DESCRIBE results to Turtle correctly."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_describe"
+    sparql = f"""
+        DESCRIBE <{SUBJECT}>
+        FROM <{graph}>
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_export_uses_default_format_for_ask():
+    """Test that execute() uses the default export format for ASK when output_format is omitted."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_default"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_default.json"
+
+    assert result is True
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_uses_default_format_for_construct():
+    """Test that execute() uses the default export format for CONSTRUCT when output_format is omitted."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct_default"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct_default.ttl"
+
+    assert isinstance(result, str)
+    assert exported_path.exists()
+    assert exported_path.read_text(encoding="utf-8").splitlines() == result.splitlines()
+
+
+def test_execute_rejects_unsupported_export_format_for_ask():
+    """Test that execute() rejects unsupported export formats for ASK queries."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_ask"))
+
+
+def test_execute_rejects_export_for_update_operations():
+    """Test that execute() rejects export for SPARQL update operations."""
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_update"))

--- a/triplestore/tests/test_oxigraph.py
+++ b/triplestore/tests/test_oxigraph.py
@@ -267,6 +267,41 @@ def test_load_from_turtle_file():
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
 
 
+def test_load_from_ntriples_file():
+    """Test loading triples from a .nt file into the store."""
+    ntriples_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".nt", encoding="utf-8") as f:
+        f.write(ntriples_data)
+        tmp_path = f.name
+
+    store = Triplestore("oxigraph", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_load_rejects_unsupported_file_format():
+    """Test that load() rejects unsupported RDF file formats."""
+    invalid_data = "this is not rdf"
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(invalid_data)
+        tmp_path = f.name
+
+    store = Triplestore("oxigraph", config=config)
+
+    with pytest.raises(ValueError, match="Unsupported RDF file format"):
+        store.load(tmp_path)
+
+    Path(tmp_path).unlink()
+
+
 def test_clear():
     """Test that clear() removes all triples from the store."""
     store = Triplestore("oxigraph", config=config)

--- a/triplestore/tests/test_qlever.py
+++ b/triplestore/tests/test_qlever.py
@@ -404,6 +404,55 @@ def test_named_graph():
     assert str(row["o"]).strip("<>") == OBJECT
 
 
+def test_select_star():
+    """Test SELECT *: verifies correct binding, completeness, and result integrity."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    # Insert multiple triples
+    triples = [
+        ("http://example.org/s1", "http://example.org/p1", "http://example.org/o1"),
+        ("http://example.org/s2", "http://example.org/p2", "http://example.org/o2"),
+        ("http://example.org/s3", "http://example.org/p3", "http://example.org/o3"),
+    ]
+
+    for s, p, o in triples:
+        store.add(s, p, o)
+
+    # SELECT * query
+    results = store.query(
+        f"""
+        SELECT * WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    # Check number of results
+    assert len(results) == len(triples)
+
+    expected_rows = [{"s": s, "p": p, "o": o} for s, p, o in triples]
+
+    # Check that all variables are present in each row
+    for row in results:
+        assert set(row.keys()) == {"s", "p", "o"}
+
+    # Check that all values are valid (strings and not None)
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Check exact match between expected and actual results (order-independent)
+    assert {tuple(sorted(r.items())) for r in results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # Ensure no duplicate rows are returned
+    assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
 def test_stop_server():
     store = Triplestore("qlever", config=config)
     store.stop_server()

--- a/triplestore/tests/test_qlever.py
+++ b/triplestore/tests/test_qlever.py
@@ -155,6 +155,133 @@ def test_query_roundtrip_add():
     assert count == 1
 
 
+def test_add_delete_with_literal_object():
+    """Test add()/delete() with a plain string literal object."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    s = "http://example.org/person1"
+    p = "http://example.org/name"
+    o = "Alice"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Alice"
+
+    store.delete(s, p, o)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+    assert results_after_delete == []
+
+
+def test_add_delete_with_typed_and_lang_literals():
+    """Test add()/delete() with typed and language-tagged literal objects."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    s1 = "http://example.org/person2"
+    p1 = "http://example.org/age"
+    o1 = 25
+
+    s2 = "http://example.org/person3"
+    p2 = "http://example.org/label"
+    o2 = {"value": "hallo", "lang": "de"}
+
+    store.add(s1, p1, o1)
+    store.add(s2, p2, o2)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results)
+    assert any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results)
+
+    store.delete(s1, p1, o1)
+    store.delete(s2, p2, o2)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert not any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results_after_delete)
+    assert not any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results_after_delete)
+
+
+def test_add_delete_with_blank_node_subject():
+    """Test add()/delete() with a blank node as subject."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    s = "_:b1"
+    p = "http://example.org/name"
+    o = "Anonymous"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Anonymous"
+
+    with pytest.raises(ValueError, match="Cannot delete triples using a blank node as subject."):
+        store.delete(s, p, o)
+
+
+def test_add_rejects_invalid_rdf_positions():
+    """Test that add() rejects literals as subjects and non-IRI predicates."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="subject of an RDF triple cannot be a literal"):
+        store.add("Alice", "http://example.org/name", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "_:p1", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "name", "Bob")
+
+
 def test_query_returns_empty_when_no_match():
     """Test that a SPARQL query returns no results when no match exists."""
     store = Triplestore("qlever", config=config)

--- a/triplestore/tests/test_qlever.py
+++ b/triplestore/tests/test_qlever.py
@@ -8,6 +8,8 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local QLever instance with HTTP API access.
 """
 
+import csv
+import json
 import tempfile
 from pathlib import Path
 
@@ -26,6 +28,9 @@ PREFIXES = """
 PREFIX ex: <http://example.org/>
 """
 SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p ?o } }"
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 WORKDIR = (Path(__file__).resolve().parent / "qlever-test-demo").resolve()
 
@@ -451,6 +456,528 @@ def test_select_star():
 
     # Ensure no duplicate rows are returned
     assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
+def test_query_export_json():
+    """Test that query() exports SELECT results to a JSON file correctly."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "qlever_results1"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_results1.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data == results
+
+    row = data[0]
+    assert row["s"] == SUBJECT
+    assert row["p"] == PREDICATE
+    assert row["o"] == OBJECT
+
+
+def test_query_export_csv():
+    """Test that query() exports SELECT results to a CSV file correctly."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "qlever_results2"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_results2.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_export_csv_with_custom_separator():
+    """Test that query() exports SELECT results to CSV using a custom separator."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    content = exported_path.read_text()
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_query_export_json_with_existing_extension():
+    """Test that query() respects an already-correct filename extension."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "already_json.json"
+    store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    assert output_file.exists()
+    assert not (TEST_FILES_DIR / "already_json.json.json").exists()
+
+
+def test_query_export_replaces_wrong_extension():
+    """Test that query() replaces a wrong filename extension with the requested one."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "results.txt"
+    store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    assert not output_file.exists()
+    assert (TEST_FILES_DIR / "results.csv").exists()
+
+
+def test_query_export_empty_results_json():
+    """Test exporting an empty SELECT result set to JSON."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        f"""
+        SELECT ?s WHERE {{
+          GRAPH <{GRAPH}> {{
+            <http://example.org/does-not-exist> ?p ?o .
+          }}
+        }}
+        """,
+        export=True,
+        output_format="json",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_export_empty_results_csv():
+    """Test exporting an empty SELECT result set to CSV still creates a valid file."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        f"""
+        SELECT ?s WHERE {{
+          GRAPH <{GRAPH}> {{
+            <http://example.org/does-not-exist> ?p ?o .
+          }}
+        }}
+        """,
+        export=True,
+        output_format="csv",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.csv"
+
+    assert results == []
+    assert exported_path.exists()
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        content = f.read()
+
+    assert not content.strip()
+
+
+def test_query_rejects_non_select_query():
+    """Test that query() rejects non-SELECT SPARQL queries."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"ASK WHERE {{ GRAPH <{config['graph']}> {{ ?s ?p ?o }} }}")
+
+
+def test_query_rejects_unsupported_export_format():
+    """Test that query() rejects unsupported export formats for SELECT queries."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename="bad_output")
+
+
+def test_query_no_export_does_not_create_file():
+    """Test that query() does not create any file when export=False."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "should_not_exist.json"
+    results = store.query(SPARQL_QUERY, export=False, output_format="json", filename=str(output_file))
+
+    assert len(results) == 1
+    assert not output_file.exists()
+
+
+def test_query_accepts_prefixed_select_with_export():
+    """Test that query() correctly detects SELECT when PREFIX declarations precede it."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    sparql = f"""
+        PREFIX ex: <http://example.org/>
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    output_file = TEST_FILES_DIR / "prefixed"
+    results = store.query(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "prefixed.json"
+
+    assert exported_path.exists()
+    assert len(results) == 1
+    assert results[0]["s"] == SUBJECT
+    assert results[0]["p"] == PREDICATE
+    assert results[0]["o"] == OBJECT
+
+
+def test_execute_export_select_json():
+    """Test that execute() exports SELECT results to JSON correctly."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_json"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+          GRAPH <{graph}> {{
+            ?s ?p ?o
+          }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+    assert data[0]["s"] == SUBJECT
+    assert data[0]["p"] == PREDICATE
+    assert data[0]["o"] == OBJECT
+
+
+def test_execute_export_select_csv():
+    """Test that execute() exports SELECT results to CSV correctly."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_csv"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+          GRAPH <{graph}> {{
+            ?s ?p ?o
+          }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_execute_export_ask_json():
+    """Test that execute() exports ASK results to JSON correctly."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_json"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt():
+    """Test that execute() exports ASK results to TXT correctly."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_txt"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl():
+    """Test that execute() exports CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+          GRAPH <{graph}> {{
+            ?s ?p ?o
+          }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+    assert PREDICATE in content
+    assert OBJECT in content
+
+
+def test_execute_export_describe_ttl():
+    """Test that execute() exports DESCRIBE results to Turtle correctly."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_export_uses_default_format_for_ask():
+    """Test that execute() uses the default export format for ASK when output_format is omitted."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_default"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_default.json"
+
+    assert result is True
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_uses_default_format_for_construct():
+    """Test that execute() uses the default export format for CONSTRUCT when output_format is omitted."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct_default"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+          GRAPH <{graph}> {{
+            ?s ?p ?o
+          }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct_default.ttl"
+
+    assert isinstance(result, str)
+    assert exported_path.exists()
+    assert exported_path.read_text(encoding="utf-8").splitlines() == result.splitlines()
+
+
+def test_execute_rejects_unsupported_export_format_for_ask():
+    """Test that execute() rejects unsupported export formats for ASK queries."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_ask"))
+
+
+def test_execute_rejects_export_for_update_operations():
+    """Test that execute() rejects export for SPARQL update operations."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+          }}
+        }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_update"))
 
 
 def test_stop_server():

--- a/triplestore/tests/test_qlever.py
+++ b/triplestore/tests/test_qlever.py
@@ -326,6 +326,41 @@ def test_load_from_turtle_file():
     )
 
 
+def test_load_from_ntriples_file():
+    """Test loading triples from a .nt file into the store."""
+    ntriples_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".nt", encoding="utf-8") as f:
+        f.write(ntriples_data)
+        tmp_path = f.name
+
+    store = Triplestore("qlever", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_load_rejects_unsupported_file_format():
+    """Test that load() rejects unsupported RDF file formats."""
+    invalid_data = "this is not rdf"
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(invalid_data)
+        tmp_path = f.name
+
+    store = Triplestore("qlever", config=config)
+
+    with pytest.raises(ValueError, match="Unsupported RDF file format"):
+        store.load(tmp_path)
+
+    Path(tmp_path).unlink()
+
+
 def test_clear():
     """Test that clear() removes all triples from the store."""
     store = Triplestore("qlever", config=config)

--- a/triplestore/tests/test_qlever.py
+++ b/triplestore/tests/test_qlever.py
@@ -1,0 +1,412 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the QLever backend of the triplestore abstraction layer.
+
+All operations are scoped within the named graph 'http://example.org/test',
+and use a local QLever instance with HTTP API access.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import requests
+from triplestore import Triplestore
+
+SUBJECT = "http://example.org/s"
+PREDICATE = "http://example.org/p"
+OBJECT = "http://example.org/o"
+
+GRAPH = "http://example.org/test"
+EX = "http://example.org/"
+
+PREFIXES = """
+PREFIX ex: <http://example.org/>
+"""
+SPARQL_QUERY = "SELECT ?s ?p ?o WHERE { GRAPH <http://example.org/test> { ?s ?p ?o } }"
+
+WORKDIR = (Path(__file__).resolve().parent / "qlever-test-demo").resolve()
+
+config = {
+    "base_url": "http://localhost:7019",
+    "graph": GRAPH,
+    "dataset": "olympics",
+    "working_directory": str(WORKDIR),
+}
+
+
+def test_initialize_server():
+    store = Triplestore("qlever", config=config)
+
+    response = requests.get(config["base_url"], timeout=5)
+    assert response.status_code in {200, 400, 404, 405}
+
+
+def test_add_and_query_triple():
+    """Test adding a triple and retrieving it via SPARQL."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    results = store.query(SPARQL_QUERY)
+
+    assert any(
+        str(row["s"]).strip("<>") == SUBJECT and
+        str(row["p"]).strip("<>") == PREDICATE and
+        str(row["o"]).strip("<>") == OBJECT
+        for row in results
+    )
+
+
+def test_multiple_triples_query():
+    """Test querying multiple triples with the same predicate-object pair."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add("http://example.org/s1", PREDICATE, OBJECT)
+    store.add("http://example.org/s2", PREDICATE, OBJECT)
+
+    query = f"""
+    {PREFIXES}
+    SELECT ?s
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?s <{PREDICATE}> <{OBJECT}> .
+      }}
+    }}
+    """
+    results = store.query(query)
+    subjects = [str(row["s"]).strip("<>") for row in results]
+
+    assert "http://example.org/s1" in subjects
+    assert "http://example.org/s2" in subjects
+    assert len(subjects) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a triple removes it from the store."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    before = store.query(f"""
+    {PREFIXES}
+    SELECT ?o WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> <{PREDICATE}> ?o .
+      }}
+    }}
+    """)
+    assert len(before) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+
+    after = store.query(f"""
+    {PREFIXES}
+    SELECT ?o WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> <{PREDICATE}> ?o .
+      }}
+    }}
+    """)
+    assert len(after) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle for a triple."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    initial_results = store.query(SPARQL_QUERY)
+    row = next(iter(initial_results))
+    s = str(row["s"]).strip("<>")
+    p = str(row["p"]).strip("<>")
+    o = str(row["o"]).strip("<>")
+
+    store.delete(s, p, o)
+
+    after_delete = store.query(SPARQL_QUERY)
+    assert not any(
+        str(r["s"]).strip("<>") == s and
+        str(r["p"]).strip("<>") == p and
+        str(r["o"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, p, o)
+
+    final_results = store.query(SPARQL_QUERY)
+    count = sum(
+        1 for r in final_results
+        if str(r["s"]).strip("<>") == s and
+           str(r["p"]).strip("<>") == p and
+           str(r["o"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a SPARQL query returns no results when no match exists."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?s
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> ?p ?o .
+      }}
+    }}
+    """)
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading triples from a .ttl file into the store."""
+    turtle_data = f"""
+    <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    store = Triplestore("qlever", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    assert any(
+        str(row["s"]).strip("<>") == SUBJECT and
+        str(row["p"]).strip("<>") == PREDICATE and
+        str(row["o"]).strip("<>") == OBJECT
+        for row in results
+    )
+
+
+def test_clear():
+    """Test that clear() removes all triples from the store."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    store.add("http://example.org/s2", PREDICATE, "http://example.org/o2")
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute() using standard SPARQL queries."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    # INSERT DATA
+    q = f"""
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+      }}
+    }}
+    """
+    out = store.execute(q)
+    assert out is None
+
+    # ASK
+    ask_q = f"""
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # SELECT
+    q = f"""
+    SELECT ?s
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?s <{PREDICATE}> <{OBJECT}> .
+      }}
+    }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["s"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    # DESCRIBE
+    q = f"DESCRIBE <{SUBJECT}>"
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert SUBJECT in desc
+
+    # CONSTRUCT
+    q = f"""
+    CONSTRUCT {{ ?s ?p ?o }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?s ?p ?o .
+      }}
+    }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert SUBJECT in cons
+    assert PREDICATE in cons
+    assert OBJECT in cons
+
+    # DELETE DATA
+    q = f"""
+    DELETE DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+      }}
+    }}
+    """
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    # Re-insert and CLEAR GRAPH
+    store.execute(f"""
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+      }}
+    }}
+    """)
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_add_duplicate_triple():
+    """Test that adding the same triple twice does not create duplicate query results."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    results = store.query(SPARQL_QUERY)
+
+    count = sum(
+        1 for r in results
+        if str(r["s"]).strip("<>") == SUBJECT and
+           str(r["p"]).strip("<>") == PREDICATE and
+           str(r["o"]).strip("<>") == OBJECT
+    )
+    assert count == 1
+
+
+def test_delete_nonexistent_triple():
+    """Test that deleting a triple that does not exist does not raise or affect existing data."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    store.delete(
+        "http://example.org/nonexistentS",
+        PREDICATE,
+        "http://example.org/nonexistentO",
+    )
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?o
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> <{PREDICATE}> ?o .
+      }}
+    }}
+    """)
+
+    assert len(results) == 1
+    assert str(results[0]["o"]).strip("<>") == OBJECT
+
+
+def test_named_graph():
+    """Test that queries scoped to the configured graph do not see triples from another named graph."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    other_graph = "http://example.org/other"
+
+    q = f"""
+    INSERT DATA {{
+      GRAPH <{other_graph}> {{
+        <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results_in_test_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?s ?p ?o
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?s ?p ?o .
+      }}
+    }}
+    """)
+
+    assert len(results_in_test_graph) == 0
+
+    results_in_other_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?s ?p ?o
+    WHERE {{
+      GRAPH <{other_graph}> {{
+        ?s ?p ?o .
+      }}
+    }}
+    """)
+
+    assert len(results_in_other_graph) == 1
+    row = results_in_other_graph[0]
+    assert str(row["s"]).strip("<>") == SUBJECT
+    assert str(row["p"]).strip("<>") == PREDICATE
+    assert str(row["o"]).strip("<>") == OBJECT
+
+
+def test_stop_server():
+    store = Triplestore("qlever", config=config)
+    store.stop_server()
+
+    with pytest.raises(requests.RequestException):
+        requests.get(config["base_url"], timeout=2)

--- a/triplestore/tests/test_rdf4j.py
+++ b/triplestore/tests/test_rdf4j.py
@@ -1,0 +1,314 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the RDF4J backend of the triplestore abstraction layer.
+
+All operations are scoped within the named graph 'http://example.org/test',
+and use a local RDF4J Server instance with REST access.
+"""
+
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from triplestore import Triplestore
+
+SUBJECT = "http://example.org/s"
+PREDICATE = "http://example.org/p"
+OBJECT = "http://example.org/o"
+
+BASE_URL = "http://localhost:8080/rdf4j-server"
+REPOSITORY = f"testns-{int(time.time())}"
+GRAPH = "http://example.org/test"
+
+SPARQL_QUERY = f"""
+SELECT ?s ?p ?o WHERE {{
+    GRAPH <{GRAPH}> {{
+        ?s ?p ?o
+    }}
+}}
+"""
+
+
+def is_rdf4j_available() -> bool:
+    try:
+        response = requests.get(f"{BASE_URL}/repositories", timeout=5)
+    except requests.RequestException:
+        return False
+    else:
+        return response.status_code == 200
+
+
+pytestmark = pytest.mark.skipif(
+    not is_rdf4j_available(),
+    reason="RDF4J instance or repository is not reachable at the configured base_url"
+)
+
+
+config = {
+    "name": REPOSITORY,
+    "base_url": BASE_URL,
+    "auth": None,
+    "graph": GRAPH,
+}
+
+
+def test_add_and_query_triple():
+    """Test adding a triple and retrieving it via SPARQL."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    results = store.query(SPARQL_QUERY)
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_multiple_triples_query():
+    """Test querying multiple triples with the same predicate-object pair."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add("http://example.org/s1", PREDICATE, OBJECT)
+    store.add("http://example.org/s2", PREDICATE, OBJECT)
+
+    results = store.query(
+        f"""
+        SELECT ?s WHERE {{
+            GRAPH <{GRAPH}> {{
+                ?s <{PREDICATE}> <{OBJECT}>
+            }}
+        }}
+        """
+    )
+    subjects = [str(row["s"]).strip("<>") for row in results]
+
+    assert "http://example.org/s1" in subjects
+    assert "http://example.org/s2" in subjects
+    assert len(subjects) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a triple removes it from the store."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    assert len(store.query(SPARQL_QUERY)) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+    results = store.query(SPARQL_QUERY)
+    assert len(results) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle to ensure consistent state after re-adding a triple."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    initial_results = store.query(SPARQL_QUERY)
+    row = next(iter(initial_results))
+    s = str(row["s"]).strip("<>")
+    p = str(row["p"]).strip("<>")
+    o = str(row["o"]).strip("<>")
+
+    store.delete(s, p, o)
+
+    after_delete = store.query(SPARQL_QUERY)
+    assert not any(
+        str(r["s"]).strip("<>") == s and
+        str(r["p"]).strip("<>") == p and
+        str(r["o"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, p, o)
+
+    final_results = store.query(SPARQL_QUERY)
+    count = sum(
+        1 for r in final_results
+        if str(r["s"]).strip("<>") == s
+        and str(r["p"]).strip("<>") == p
+        and str(r["o"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a SPARQL query returns no results when no match exists."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    results = store.query(
+        f"""
+        SELECT ?s WHERE {{
+            GRAPH <{GRAPH}> {{
+                <http://example.org/unknown> ?p ?o
+            }}
+        }}
+        """
+    )
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading triples from a .ttl file into the store."""
+    turtle_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_clear():
+    """Test that clear() removes all triples from the store."""
+    store = Triplestore("rdf4j", config=config)
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute(): INSERT/DELETE/CLEAR + ASK/SELECT/DESCRIBE/CONSTRUCT."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    # INSERT DATA
+    q = f"INSERT DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    out = store.execute(q)
+    assert out is None
+
+    # ASK
+    ask_q = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # SELECT
+    q = f"""
+        SELECT ?s WHERE {{
+            GRAPH <{graph}> {{
+                ?s <{PREDICATE}> <{OBJECT}>
+            }}
+        }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["s"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    # DESCRIBE
+    q = f"DESCRIBE <{SUBJECT}>"
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert SUBJECT in desc
+
+    # CONSTRUCT
+    q = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert SUBJECT in cons
+    assert PREDICATE in cons
+    assert OBJECT in cons
+
+    # DELETE DATA
+    q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    # Re-insert and CLEAR GRAPH
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_select_star():
+    """Test SELECT *: verifies correct binding, completeness, and result integrity."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    triples = [
+        ("http://example.org/s1", "http://example.org/p1", "http://example.org/o1"),
+        ("http://example.org/s2", "http://example.org/p2", "http://example.org/o2"),
+        ("http://example.org/s3", "http://example.org/p3", "http://example.org/o3"),
+    ]
+
+    for s, p, o in triples:
+        store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT * WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == len(triples)
+
+    expected_rows = [{"s": s, "p": p, "o": o} for s, p, o in triples]
+
+    for row in results:
+        assert set(row.keys()) == {"s", "p", "o"}
+
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    assert {tuple(sorted(r.items())) for r in results} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+    assert len(results) == len({tuple(sorted(r.items())) for r in results})

--- a/triplestore/tests/test_rdf4j.py
+++ b/triplestore/tests/test_rdf4j.py
@@ -8,6 +8,8 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local RDF4J Server instance with REST access.
 """
 
+import csv
+import json
 import tempfile
 import time
 from pathlib import Path
@@ -31,6 +33,9 @@ SELECT ?s ?p ?o WHERE {{
     }}
 }}
 """
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 def is_rdf4j_available() -> bool:
@@ -312,3 +317,525 @@ def test_select_star():
     }
 
     assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
+def test_query_export_json():
+    """Test that query() exports SELECT results to a JSON file correctly."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "rdf4j_results1"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_results1.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data == results
+
+    row = data[0]
+    assert row["s"] == SUBJECT
+    assert row["p"] == PREDICATE
+    assert row["o"] == OBJECT
+
+
+def test_query_export_csv():
+    """Test that query() exports SELECT results to a CSV file correctly."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "rdf4j_results2"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_results2.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_export_csv_with_custom_separator():
+    """Test that query() exports SELECT results to CSV using a custom separator."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    content = exported_path.read_text()
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_query_export_json_with_existing_extension():
+    """Test that query() respects an already-correct filename extension."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "already_json.json"
+    store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    assert output_file.exists()
+    assert not (TEST_FILES_DIR / "already_json.json.json").exists()
+
+
+def test_query_export_replaces_wrong_extension():
+    """Test that query() replaces a wrong filename extension with the requested one."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "results.txt"
+    store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    assert not output_file.exists()
+    assert (TEST_FILES_DIR / "results.csv").exists()
+
+
+def test_query_export_empty_results_json():
+    """Test exporting an empty SELECT result set to JSON."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        f"""
+        SELECT ?s WHERE {{
+            GRAPH <{GRAPH}> {{
+                <http://example.org/does-not-exist> ?p ?o
+            }}
+        }}
+        """,
+        export=True,
+        output_format="json",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_export_empty_results_csv():
+    """Test exporting an empty SELECT result set to CSV still creates a valid file."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        f"""
+        SELECT ?s WHERE {{
+            GRAPH <{GRAPH}> {{
+                <http://example.org/does-not-exist> ?p ?o
+            }}
+        }}
+        """,
+        export=True,
+        output_format="csv",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.csv"
+
+    assert results == []
+    assert exported_path.exists()
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        content = f.read()
+
+    assert not content.strip()
+
+
+def test_query_rejects_non_select_query():
+    """Test that query() rejects non-SELECT SPARQL queries."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"ASK WHERE {{ GRAPH <{config['graph']}> {{ ?s ?p ?o }} }}")
+
+
+def test_query_rejects_unsupported_export_format():
+    """Test that query() rejects unsupported export formats for SELECT queries."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename="bad_output")
+
+
+def test_query_no_export_does_not_create_file():
+    """Test that query() does not create any file when export=False."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "should_not_exist.json"
+    results = store.query(SPARQL_QUERY, export=False, output_format="json", filename=str(output_file))
+
+    assert len(results) == 1
+    assert not output_file.exists()
+
+
+def test_query_accepts_prefixed_select_with_export():
+    """Test that query() correctly detects SELECT when PREFIX declarations precede it."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    sparql = f"""
+        PREFIX ex: <http://example.org/>
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    output_file = TEST_FILES_DIR / "prefixed"
+    results = store.query(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "prefixed.json"
+
+    assert exported_path.exists()
+    assert len(results) == 1
+    assert results[0]["s"] == SUBJECT
+    assert results[0]["p"] == PREDICATE
+    assert results[0]["o"] == OBJECT
+
+
+def test_execute_export_select_json():
+    """Test that execute() exports SELECT results to JSON correctly."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_json"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+    assert data[0]["s"] == SUBJECT
+    assert data[0]["p"] == PREDICATE
+    assert data[0]["o"] == OBJECT
+
+
+def test_execute_export_select_csv():
+    """Test that execute() exports SELECT results to CSV correctly."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_csv"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_execute_export_ask_json():
+    """Test that execute() exports ASK results to JSON correctly."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_json"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt():
+    """Test that execute() exports ASK results to TXT correctly."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_txt"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl():
+    """Test that execute() exports CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+    assert PREDICATE in content
+    assert OBJECT in content
+
+
+def test_execute_export_describe_ttl():
+    """Test that execute() exports DESCRIBE results to Turtle correctly."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_export_uses_default_format_for_ask():
+    """Test that execute() uses the default export format for ASK when output_format is omitted."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_default"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_default.json"
+
+    assert result is True
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_uses_default_format_for_construct():
+    """Test that execute() uses the default export format for CONSTRUCT when output_format is omitted."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct_default"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct_default.ttl"
+
+    assert isinstance(result, str)
+    assert exported_path.exists()
+    assert exported_path.read_text(encoding="utf-8").splitlines() == result.splitlines()
+
+
+def test_execute_rejects_unsupported_export_format_for_ask():
+    """Test that execute() rejects unsupported export formats for ASK queries."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_ask"))
+
+
+def test_execute_rejects_export_for_update_operations():
+    """Test that execute() rejects export for SPARQL update operations."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_update"))

--- a/triplestore/tests/test_rdf4j.py
+++ b/triplestore/tests/test_rdf4j.py
@@ -145,6 +145,133 @@ def test_query_roundtrip_add():
     assert count == 1
 
 
+def test_add_delete_with_literal_object():
+    """Test add()/delete() with a plain string literal object."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    s = "http://example.org/person1"
+    p = "http://example.org/name"
+    o = "Alice"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Alice"
+
+    store.delete(s, p, o)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <{s}> <{p}> ?o
+            }}
+        }}
+        """
+    )
+    assert results_after_delete == []
+
+
+def test_add_delete_with_typed_and_lang_literals():
+    """Test add()/delete() with typed and language-tagged literal objects."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    s1 = "http://example.org/person2"
+    p1 = "http://example.org/age"
+    o1 = 25
+
+    s2 = "http://example.org/person3"
+    p2 = "http://example.org/label"
+    o2 = {"value": "hallo", "lang": "de"}
+
+    store.add(s1, p1, o1)
+    store.add(s2, p2, o2)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results)
+    assert any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results)
+
+    store.delete(s1, p1, o1)
+    store.delete(s2, p2, o2)
+
+    results_after_delete = store.query(
+        f"""
+        SELECT ?s ?p ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert not any(r["s"] == s1 and r["p"] == p1 and r["o"] == "25" for r in results_after_delete)
+    assert not any(r["s"] == s2 and r["p"] == p2 and r["o"] == "hallo" for r in results_after_delete)
+
+
+def test_add_delete_with_blank_node_subject():
+    """Test add()/delete() with a blank node as subject."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    s = "_:b1"
+    p = "http://example.org/name"
+    o = "Anonymous"
+
+    store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT ?s ?o WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s <{p}> ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == 1
+    assert results[0]["o"] == "Anonymous"
+
+    with pytest.raises(ValueError, match="Cannot delete triples using a blank node as subject."):
+        store.delete(s, p, o)
+
+
+def test_add_rejects_invalid_rdf_positions():
+    """Test that add() rejects literals as subjects and non-IRI predicates."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="subject of an RDF triple cannot be a literal"):
+        store.add("Alice", "http://example.org/name", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "_:p1", "Bob")
+
+    with pytest.raises(ValueError, match="predicate of an RDF triple must be an IRI"):
+        store.add("http://example.org/person4", "name", "Bob")
+
+
 def test_query_returns_empty_when_no_match():
     """Test that a SPARQL query returns no results when no match exists."""
     store = Triplestore("rdf4j", config=config)

--- a/triplestore/tests/test_rdf4j.py
+++ b/triplestore/tests/test_rdf4j.py
@@ -309,6 +309,41 @@ def test_load_from_turtle_file():
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
 
 
+def test_load_from_ntriples_file():
+    """Test loading triples from a .nt file into the store."""
+    ntriples_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".nt", encoding="utf-8") as f:
+        f.write(ntriples_data)
+        tmp_path = f.name
+
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_load_rejects_unsupported_file_format():
+    """Test that load() rejects unsupported RDF file formats."""
+    invalid_data = "this is not rdf"
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(invalid_data)
+        tmp_path = f.name
+
+    store = Triplestore("rdf4j", config=config)
+
+    with pytest.raises(ValueError, match="Unsupported RDF file format"):
+        store.load(tmp_path)
+
+    Path(tmp_path).unlink()
+
+
 def test_clear():
     """Test that clear() removes all triples from the store."""
     store = Triplestore("rdf4j", config=config)

--- a/triplestore/tests/test_virtuoso.py
+++ b/triplestore/tests/test_virtuoso.py
@@ -1,0 +1,296 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the Virtuoso backend of the triplestore abstraction layer.
+
+All operations are scoped within a named graph, and use a local Virtuoso instance with SPARQL HTTP access.
+"""
+
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from triplestore import Triplestore
+
+SUBJECT = "http://example.org/s"
+PREDICATE = "http://example.org/p"
+OBJECT = "http://example.org/o"
+
+
+def is_virtuoso_available():
+    try:
+        response = requests.get("http://localhost:8890/sparql", timeout=2)
+    except requests.RequestException:
+        return False
+    else:
+        return response.status_code in {200, 401, 403}
+
+
+pytestmark = pytest.mark.skipif(
+    not is_virtuoso_available(),
+    reason="Virtuoso instance is not reachable at http://localhost:8890/sparql",
+)
+
+
+config = {
+    "base_url": "http://localhost:8890",
+    "graph": f"http://example.org/testns-{int(time.time())}",
+}
+
+SPARQL_QUERY = f"""
+SELECT ?s ?p ?o WHERE {{
+    GRAPH <{config['graph']}> {{
+        ?s ?p ?o
+    }}
+}}
+"""
+
+
+def test_add_and_query_triple():
+    """Test adding a triple and retrieving it via SPARQL."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    results = store.query(SPARQL_QUERY)
+
+    bindings = [str(binding) for binding in results]
+    assert {"s": SUBJECT, "p": PREDICATE, "o": OBJECT} in results
+
+
+def test_multiple_triples_query():
+    """Test querying multiple triples with the same predicate-object pair."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add("http://example.org/s1", PREDICATE, OBJECT)
+    store.add("http://example.org/s2", PREDICATE, OBJECT)
+
+    results = store.query(
+        f"SELECT ?s WHERE {{ GRAPH <{config['graph']}> {{ ?s <{PREDICATE}> <{OBJECT}> }} }}"
+    )
+    subjects = [str(row["s"]).strip("<>") for row in results]
+
+    assert "http://example.org/s1" in subjects
+    assert "http://example.org/s2" in subjects
+    assert len(subjects) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a triple removes it from the store."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    assert len(store.query(SPARQL_QUERY)) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+    results = store.query(SPARQL_QUERY)
+    assert len(results) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle to ensure consistent state after re-adding a triple."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    initial_results = store.query(SPARQL_QUERY)
+    row = next(iter(initial_results))
+    s = str(row["s"]).strip("<>")
+    p = str(row["p"]).strip("<>")
+    o = str(row["o"]).strip("<>")
+
+    store.delete(s, p, o)
+
+    after_delete = store.query(SPARQL_QUERY)
+    assert not any(
+        str(r["s"]).strip("<>") == s
+        and str(r["p"]).strip("<>") == p
+        and str(r["o"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, p, o)
+
+    final_results = store.query(SPARQL_QUERY)
+    count = sum(
+        1
+        for r in final_results
+        if str(r["s"]).strip("<>") == s
+        and str(r["p"]).strip("<>") == p
+        and str(r["o"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a SPARQL query returns no results when no match exists."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    results = store.query("SELECT ?s WHERE { <http://example.org/unknown> ?p ?o }")
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading triples from a .ttl file into the store."""
+    turtle_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_clear():
+    """Test that clear() removes all triples from the store."""
+    store = Triplestore("virtuoso", config=config)
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute(): INSERT/DELETE/CLEAR + ASK/SELECT/DESCRIBE/CONSTRUCT."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    q = f"INSERT DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    out = store.execute(q)
+    assert out is None
+
+    ask_q = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    q = f"""
+        SELECT ?s WHERE {{
+            GRAPH <{graph}> {{
+                ?s <{PREDICATE}> <{OBJECT}>
+            }}
+        }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["s"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    # DESCRIBE
+    q = f"""
+        DESCRIBE <{SUBJECT}>
+        FROM <{graph}>
+    """
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert "s" in desc
+    assert "p" in desc
+    assert "o" in desc
+
+    q = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert "s" in cons
+    assert "p" in cons
+    assert "o" in cons
+    assert "@prefix" in desc or "http://example.org/" in cons
+
+    q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    store.execute(
+        f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+        """
+    )
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_select_star():
+    """Test SELECT *: verifies correct binding, completeness, and result integrity."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    triples = [
+        ("http://example.org/s1", "http://example.org/p1", "http://example.org/o1"),
+        ("http://example.org/s2", "http://example.org/p2", "http://example.org/o2"),
+        ("http://example.org/s3", "http://example.org/p3", "http://example.org/o3"),
+    ]
+
+    for s, p, o in triples:
+        store.add(s, p, o)
+
+    results = store.query(
+        f"""
+        SELECT * WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+        """
+    )
+
+    assert len(results) == len(triples)
+
+    expected_rows = [{"s": s, "p": p, "o": o} for s, p, o in triples]
+
+    for row in results:
+        assert set(row.keys()) == {"s", "p", "o"}
+
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    assert {tuple(sorted(r.items())) for r in results} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+    assert len(results) == len({tuple(sorted(r.items())) for r in results})

--- a/triplestore/tests/test_virtuoso.py
+++ b/triplestore/tests/test_virtuoso.py
@@ -6,7 +6,8 @@ Tests for the Virtuoso backend of the triplestore abstraction layer.
 
 All operations are scoped within a named graph, and use a local Virtuoso instance with SPARQL HTTP access.
 """
-
+import csv
+import json
 import tempfile
 import time
 from pathlib import Path
@@ -18,6 +19,9 @@ from triplestore import Triplestore
 SUBJECT = "http://example.org/s"
 PREDICATE = "http://example.org/p"
 OBJECT = "http://example.org/o"
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 def is_virtuoso_available():
@@ -294,3 +298,528 @@ def test_select_star():
     }
 
     assert len(results) == len({tuple(sorted(r.items())) for r in results})
+
+
+def test_query_export_json():
+    """Test that query() exports SELECT results to a JSON file correctly."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "virtuoso_results1"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_results1.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data == results
+
+    row = data[0]
+    assert row["s"] == SUBJECT
+    assert row["p"] == PREDICATE
+    assert row["o"] == OBJECT
+
+
+def test_query_export_csv():
+    """Test that query() exports SELECT results to a CSV file correctly."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "virtuoso_results2"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_results2.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_export_csv_with_custom_separator():
+    """Test that query() exports SELECT results to CSV using a custom separator."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    content = exported_path.read_text()
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_query_export_json_with_existing_extension():
+    """Test that query() respects an already-correct filename extension."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "already_json.json"
+    store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    assert output_file.exists()
+    assert not (TEST_FILES_DIR / "already_json.json.json").exists()
+
+
+def test_query_export_replaces_wrong_extension():
+    """Test that query() replaces a wrong filename extension with the requested one."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "results.txt"
+    store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    assert not output_file.exists()
+    assert (TEST_FILES_DIR / "results.csv").exists()
+
+
+def test_query_export_empty_results_json():
+    """Test exporting an empty SELECT result set to JSON."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        f"""
+        SELECT ?s WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <http://example.org/does-not-exist> ?p ?o
+            }}
+        }}
+        """,
+        export=True,
+        output_format="json",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_export_empty_results_csv():
+    """Test exporting an empty SELECT result set to CSV still creates a valid file."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "empty_results"
+    results = store.query(
+        f"""
+        SELECT ?s WHERE {{
+            GRAPH <{config["graph"]}> {{
+                <http://example.org/does-not-exist> ?p ?o
+            }}
+        }}
+        """,
+        export=True,
+        output_format="csv",
+        filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "empty_results.csv"
+
+    assert results == []
+    assert exported_path.exists()
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        content = f.read()
+
+    assert not content.strip()
+
+
+def test_query_rejects_non_select_query():
+    """Test that query() rejects non-SELECT SPARQL queries."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"ASK WHERE {{ GRAPH <{config['graph']}> {{ ?s ?p ?o }} }}")
+
+
+def test_query_rejects_unsupported_export_format():
+    """Test that query() rejects unsupported export formats for SELECT queries."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename="bad_output")
+
+
+def test_query_no_export_does_not_create_file():
+    """Test that query() does not create any file when export=False."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    output_file = TEST_FILES_DIR / "should_not_exist.json"
+    results = store.query(SPARQL_QUERY, export=False, output_format="json", filename=str(output_file))
+
+    assert len(results) == 1
+    assert not output_file.exists()
+
+
+def test_query_accepts_prefixed_select_with_export():
+    """Test that query() correctly detects SELECT when PREFIX declarations precede it."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    sparql = f"""
+        PREFIX ex: <http://example.org/>
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{config["graph"]}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    output_file = TEST_FILES_DIR / "prefixed"
+    results = store.query(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "prefixed.json"
+
+    assert exported_path.exists()
+    assert len(results) == 1
+    assert results[0]["s"] == SUBJECT
+    assert results[0]["p"] == PREDICATE
+    assert results[0]["o"] == OBJECT
+
+
+def test_execute_export_select_json():
+    """Test that execute() exports SELECT results to JSON correctly."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_json"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+    assert data[0]["s"] == SUBJECT
+    assert data[0]["p"] == PREDICATE
+    assert data[0]["o"] == OBJECT
+
+
+def test_execute_export_select_csv():
+    """Test that execute() exports SELECT results to CSV correctly."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_select_csv"
+    sparql = f"""
+        SELECT ?s ?p ?o
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    results = store.execute(sparql, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 1
+    assert rows[0]["s"] == SUBJECT
+    assert rows[0]["p"] == PREDICATE
+    assert rows[0]["o"] == OBJECT
+
+
+def test_execute_export_ask_json():
+    """Test that execute() exports ASK results to JSON correctly."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_json"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt():
+    """Test that execute() exports ASK results to TXT correctly."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_txt"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl():
+    """Test that execute() exports CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "s" in content
+    assert "p" in content
+    assert "o" in content
+
+
+def test_execute_export_describe_ttl():
+    """Test that execute() exports DESCRIBE results to Turtle correctly."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_describe"
+    sparql = f"""
+        DESCRIBE <{SUBJECT}>
+        FROM <{graph}>
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "s" in content
+
+
+def test_execute_export_uses_default_format_for_ask():
+    """Test that execute() uses the default export format for ASK when output_format is omitted."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_ask_default"
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_ask_default.json"
+
+    assert result is True
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_uses_default_format_for_construct():
+    """Test that execute() uses the default export format for CONSTRUCT when output_format is omitted."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    store.execute(f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """)
+
+    output_file = TEST_FILES_DIR / "execute_construct_default"
+    sparql = f"""
+        CONSTRUCT {{ ?s ?p ?o }}
+        WHERE {{
+            GRAPH <{graph}> {{
+                ?s ?p ?o
+            }}
+        }}
+    """
+
+    result = store.execute(sparql, export=True, filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_construct_default.ttl"
+
+    assert isinstance(result, str)
+    assert exported_path.exists()
+    assert exported_path.read_text(encoding="utf-8").splitlines() == result.splitlines()
+
+
+def test_execute_rejects_unsupported_export_format_for_ask():
+    """Test that execute() rejects unsupported export formats for ASK queries."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_ask"))
+
+
+def test_execute_rejects_export_for_update_operations():
+    """Test that execute() rejects export for SPARQL update operations."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+    sparql = f"""
+        INSERT DATA {{
+            GRAPH <{graph}> {{
+                <{SUBJECT}> <{PREDICATE}> <{OBJECT}> .
+            }}
+        }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_update"))

--- a/triplestore/tests/test_virtuoso.py
+++ b/triplestore/tests/test_virtuoso.py
@@ -161,6 +161,41 @@ def test_load_from_turtle_file():
     assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
 
 
+def test_load_from_ntriples_file():
+    """Test loading triples from a .nt file into the store."""
+    ntriples_data = "<http://example.org/s> <http://example.org/p> <http://example.org/o> ."
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".nt", encoding="utf-8") as f:
+        f.write(ntriples_data)
+        tmp_path = f.name
+
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and PREDICATE in b and OBJECT in b for b in bindings)
+
+
+def test_load_rejects_unsupported_file_format():
+    """Test that load() rejects unsupported RDF file formats."""
+    invalid_data = "this is not rdf"
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt", encoding="utf-8") as f:
+        f.write(invalid_data)
+        tmp_path = f.name
+
+    store = Triplestore("virtuoso", config=config)
+
+    with pytest.raises(ValueError, match="Unsupported RDF file format"):
+        store.load(tmp_path)
+
+    Path(tmp_path).unlink()
+
+
 def test_clear():
     """Test that clear() removes all triples from the store."""
     store = Triplestore("virtuoso", config=config)

--- a/triplestore/tests_GeoSPARQL/test_all_backends.py
+++ b/triplestore/tests_GeoSPARQL/test_all_backends.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import pytest
+
+
+def main() -> int:
+    files = [
+        "triplestore/tests_GeoSPARQL/test_allegrograph.py",
+        "triplestore/tests_GeoSPARQL/test_graphdb.py",
+        "triplestore/tests_GeoSPARQL/test_jena.py",
+        "triplestore/tests_GeoSPARQL/test_qlever.py"
+    ]
+
+    # Allow passing through extra pytest args, e.g. -q or -k pattern
+    extra_args = sys.argv[1:]
+    return pytest.main(files + extra_args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/triplestore/tests_GeoSPARQL/test_allegrograph.py
+++ b/triplestore/tests_GeoSPARQL/test_allegrograph.py
@@ -8,8 +8,11 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local AllegroGraph instance with SPARQL HTTP API access.
 """
 
+import csv
+import json
 import tempfile
 import time
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -45,6 +48,9 @@ WHERE {{
   }}
 }}
 """
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 REPO_NAME = f"testns-{int(time.time())}"
@@ -923,3 +929,553 @@ def test_execute_geosparql():
     clr_out = store.execute(clear_q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def _load_basic_geosparql_dataset(store: Triplestore) -> None:
+    """Load a small GeoSPARQL dataset used by export-oriented tests."""
+    store.clear()
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+
+def test_query_export_json_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_results_json"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_results_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in data
+    ]
+
+    expected_rows = [
+        {"feature": f"{EX}featureA", "geom": f"{EX}geomA", "wkt": POINT_A},
+        {"feature": f"{EX}featureB", "geom": f"{EX}geomB", "wkt": POINT_B},
+        {"feature": f"{EX}featureBox", "geom": f"{EX}geomBox", "wkt": POLYGON},
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_rows} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+
+def test_query_export_csv_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_results_csv"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_results_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in rows
+    ]
+
+    expected_rows = [
+        {"feature": f"{EX}featureA", "geom": f"{EX}geomA", "wkt": POINT_A},
+        {"feature": f"{EX}featureB", "geom": f"{EX}geomB", "wkt": POINT_B},
+        {"feature": f"{EX}featureBox", "geom": f"{EX}geomBox", "wkt": POLYGON},
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_rows} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+
+def test_query_export_csv_with_custom_separator_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV using a custom separator."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_query_export_empty_results_json_geosparql():
+    """Test exporting an empty GeoSPARQL SELECT result set to JSON."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_empty_json"
+    results = store.query(
+        f"""
+        {PREFIXES}
+        SELECT ?feature ?geom ?wkt
+        WHERE {{
+          GRAPH <{GRAPH}> {{
+            <http://example.org/unknown> geo:hasGeometry ?geom .
+            ?geom geo:asWKT ?wkt .
+            BIND(<http://example.org/unknown> AS ?feature)
+          }}
+        }}
+        """,
+        export=True, output_format="json", filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_empty_json.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_rejects_non_select_geosparql():
+    """Test that query() rejects non-SELECT GeoSPARQL/SPARQL queries."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"""
+        {PREFIXES}
+        ASK WHERE {{
+          GRAPH <{GRAPH}> {{
+            ?feature geo:hasGeometry ?geom .
+          }}
+        }}
+        """)
+
+
+def test_query_rejects_unsupported_export_format_geosparql():
+    """Test that query() rejects unsupported export formats for GeoSPARQL SELECT queries."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename=str(TEST_FILES_DIR / "bad_geo_output"))
+
+
+def test_execute_export_select_json_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_json"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+
+def test_execute_export_select_csv_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_csv"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_execute_export_ask_json_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to JSON correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_json"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to TXT correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_txt"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_construct"
+    sparql = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "featureA" in content
+    assert "geomA" in content
+
+
+def test_execute_export_describe_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL DESCRIBE results to Turtle correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_rejects_unsupported_export_format_for_ask_geosparql():
+    """Test that execute() rejects unsupported export formats for GeoSPARQL ASK queries."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_geosparql_ask"))
+
+
+def test_execute_rejects_export_for_update_operations_geosparql():
+    """Test that execute() rejects export for GeoSPARQL update operations."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_geosparql_update"))
+
+
+def test_query_export_geojson_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_results_geojson"
+    results = store.query(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_results_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+    returned_features = {
+        feature["properties"]["feature"].strip("<>")
+        for feature in data["features"]
+    }
+    assert returned_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+        f"{EX}featureBox",
+    }
+
+    for feature in data["features"]:
+        assert feature["type"] == "Feature"
+        assert "geometry" in feature
+        assert "properties" in feature
+        assert feature["geometry"]["type"] in {"Point", "Polygon"}
+
+
+def test_execute_export_geojson_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_geojson"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+
+def test_query_export_geojson_rejects_non_geojson_values():
+    """Test that GeoJSON export fails when the SELECT results contain neither GeoJSON nor WKT."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Cannot export SELECT results as geospatial data"):
+        store.query(sparql, export=True, output_format="geojson", filename=str(TEST_FILES_DIR / "bad_geosparql_geojson"))
+
+
+def test_query_export_empty_results_geojson():
+    """Test exporting an empty GeoSPARQL SELECT result set to GeoJSON."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?wkt
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        BIND(<http://example.org/unknown> AS ?feature)
+      }}
+    }}
+    """
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_empty_geojson"
+    results = store.query(sparql, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_empty_geojson.geojson"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"type": "FeatureCollection", "features": []}
+
+
+def test_query_export_kml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KML correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_results_kml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_results_kml.kml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "<kml" in content
+    assert "<Placemark>" in content
+    assert "<Point>" in content or "<Polygon>" in content
+
+
+def test_query_export_kmz_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_results_kmz"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_results_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_execute_export_kmz_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_kmz"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_query_export_gml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GML correctly."""
+    store = Triplestore("allegrograph", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "allegrograph_geosparql_results_gml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="gml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "allegrograph_geosparql_results_gml.gml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "FeatureCollection" in content
+    assert "featureMember" in content
+    assert "Point" in content or "Polygon" in content

--- a/triplestore/tests_GeoSPARQL/test_allegrograph.py
+++ b/triplestore/tests_GeoSPARQL/test_allegrograph.py
@@ -649,3 +649,277 @@ def test_named_graph():
     row = results_in_other_graph[0]
     assert str(row["feature"]).strip("<>") == SUBJECT
     assert str(row["geom"]).strip("<>") == OBJECT
+
+
+def test_select_star():
+    """Test SELECT * for GeoSPARQL data: verifies bindings for feature, geometry, and WKT."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    # Insert two point features and one polygon feature
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    # SELECT * with GeoSPARQL FILTER
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT * WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?wkt, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """)
+
+    # Expect 2 results (featureA, featureB)
+    assert len(results) == 2
+
+    expected_rows = [
+        {
+            "feature": f"{EX}featureA",
+            "geom": f"{EX}geomA",
+            "wkt": POINT_A,
+            "boxWKT": POLYGON,
+        },
+        {
+            "feature": f"{EX}featureB",
+            "geom": f"{EX}geomB",
+            "wkt": POINT_B,
+            "boxWKT": POLYGON,
+        },
+    ]
+
+    # Check all expected variables are present
+    for row in results:
+        assert set(row.keys()) == {"feature", "geom", "wkt", "boxWKT"}
+
+    # Check values are valid
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Normalize WKT literals (strip datatype if needed)
+    normalized_results = [
+        {
+            "feature": str(r["feature"]).strip("<>"),
+            "geom": str(r["geom"]).strip("<>"),
+            "wkt": str(r["wkt"]),
+            "boxWKT": str(r["boxWKT"]),
+        }
+        for r in results
+    ]
+
+    # Exact match (order-independent)
+    assert {tuple(sorted(r.items())) for r in normalized_results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # No duplicates
+    assert len(results) == len({tuple(sorted(r.items())) for r in normalized_results})
+
+
+def test_execute_geosparql():
+    """End-to-end test for execute() using several GeoSPARQL spatial functions."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    point_outside = "POINT(23.7600 38.0100)"
+    polygon_overlap = (
+        "POLYGON((23.7350 37.9850, 23.7500 37.9850, "
+        "23.7500 37.9950, 23.7350 37.9950, 23.7350 37.9850))"
+    )
+
+    # INSERT GeoSPARQL dataset
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureOutside a ex:Feature ;
+            geo:hasGeometry ex:geomOutside .
+        ex:geomOutside a geo:Geometry ;
+            geo:asWKT "{point_outside}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+
+        ex:featureOverlap a ex:Feature ;
+            geo:hasGeometry ex:geomOverlap .
+        ex:geomOverlap a geo:Geometry ;
+            geo:asWKT "{polygon_overlap}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(insert_q)
+    assert out is None
+
+    # ASK: base triple exists
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # sfWithin: points A and B are within the polygon
+    within_q = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature NOT IN (ex:featureBox, ex:featureOverlap, ex:featureOutside))
+    }}
+    """
+    within_res = store.execute(within_q)
+    assert isinstance(within_res, list)
+    within_features = {str(r["feature"]).strip("<>") for r in within_res}
+    assert within_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+    }
+
+    # sfContains: polygon contains point A
+    contains_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomA geo:asWKT ?pointWKT .
+        FILTER(geof:sfContains(?boxWKT, ?pointWKT))
+      }}
+    }}
+    """
+    contains_res = store.execute(contains_q)
+    assert isinstance(contains_res, bool)
+    assert contains_res is True
+
+    # sfIntersects: overlapping polygons intersect
+    intersects_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomOverlap geo:asWKT ?overlapWKT .
+        FILTER(geof:sfIntersects(?boxWKT, ?overlapWKT))
+      }}
+    }}
+    """
+    intersects_res = store.execute(intersects_q)
+    assert isinstance(intersects_res, bool)
+    assert intersects_res is True
+
+    # sfDisjoint: outside point is disjoint from the box polygon
+    disjoint_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomOutside geo:asWKT ?outsideWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfDisjoint(?outsideWKT, ?boxWKT))
+      }}
+    }}
+    """
+    disjoint_res = store.execute(disjoint_q)
+    assert isinstance(disjoint_res, bool)
+    assert disjoint_res is True
+
+    # sfEquals: a geometry equals itself
+    equals_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfEquals(?boxWKT, ?boxWKT))
+      }}
+    }}
+    """
+    equals_res = store.execute(equals_q)
+    assert isinstance(equals_res, bool)
+    assert equals_res is True
+
+    # CONSTRUCT on the same dataset
+    construct_q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+    cons = store.execute(construct_q)
+    assert isinstance(cons, str)
+    assert "featureA" in cons
+    assert "geomA" in cons
+    assert "featureBox" in cons
+    assert "geomBox" in cons
+
+    # DELETE one relation and verify removal
+    delete_q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{EX}featureA> <{PREDICATE}> <{EX}geomA> }} }}"
+    del_out = store.execute(delete_q)
+    assert del_out is None
+
+    verify_delete_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    assert store.execute(verify_delete_q) is False
+
+    # CLEAR GRAPH and verify it is empty
+    clear_q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(clear_q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False

--- a/triplestore/tests_GeoSPARQL/test_allegrograph.py
+++ b/triplestore/tests_GeoSPARQL/test_allegrograph.py
@@ -1,0 +1,651 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GeoSPARQL tests for the AllegroGraph backend of the triplestore abstraction layer.
+
+All operations are scoped within the named graph 'http://example.org/test',
+and use a local AllegroGraph instance with SPARQL HTTP API access.
+"""
+
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from triplestore import Triplestore
+
+SUBJECT = "http://example.org/featureA"
+PREDICATE = "http://www.opengis.net/ont/geosparql#hasGeometry"
+OBJECT = "http://example.org/geomA"
+
+GRAPH = "http://example.org/test"
+EX = "http://example.org/"
+GEO = "http://www.opengis.net/ont/geosparql#"
+
+POINT_A = "POINT(23.7275 37.9838)"
+POINT_B = "POINT(23.7300 37.9845)"
+POLYGON = "POLYGON((23.7200 37.9800, 23.7400 37.9800, 23.7400 37.9900, 23.7200 37.9900, 23.7200 37.9800))"
+
+PREFIXES = """
+PREFIX ex:   <http://example.org/>
+PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+"""
+
+SPARQL_QUERY = f"""
+{PREFIXES}
+SELECT ?feature ?geom ?wkt
+WHERE {{
+  GRAPH <{GRAPH}> {{
+    ?feature geo:hasGeometry ?geom .
+    ?geom geo:asWKT ?wkt .
+  }}
+}}
+"""
+
+
+REPO_NAME = f"testns-{int(time.time())}"
+
+config = {
+    "base_url": "http://localhost:10035",
+    "name": REPO_NAME,
+    "graph": GRAPH,
+}
+
+
+def is_allegrograph_available():
+    try:
+        url = config["base_url"]
+        response = requests.get(url, timeout=2)
+    except requests.RequestException:
+        return False
+    else:
+        return response.status_code in {200, 401, 403}
+
+
+pytestmark = pytest.mark.skipif(
+    not is_allegrograph_available(),
+    reason=f"AllegroGraph instance is not reachable at {config['base_url']}"
+)
+
+
+def test_add_and_query_triple():
+    """Test adding a geometry triple-pattern and retrieving it via GeoSPARQL/SPARQL."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    query = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query)
+
+    results = store.query(SPARQL_QUERY)
+    bindings = [str(binding) for binding in results]
+
+    assert any(SUBJECT in b and OBJECT in b and POINT_A in b for b in bindings)
+
+
+def test_multiple_triples_query():
+    """Test querying multiple geometries that are within the same polygon."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    query1 = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query1)
+
+    query2 = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """
+    results = store.query(query2)
+    features = [str(row["feature"]).strip("<>") for row in results]
+
+    assert f"{EX}featureA" in features
+    assert f"{EX}featureB" in features
+    assert len(features) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a geometry relation removes it from the store."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    before = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(before) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+
+    after = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(after) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle for a geometry relation."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    initial_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    row = next(iter(initial_results))
+    s = str(row["feature"]).strip("<>")
+    o = str(row["geom"]).strip("<>")
+
+    store.delete(s, PREDICATE, o)
+
+    after_delete = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert not any(
+        str(r["feature"]).strip("<>") == s and
+        str(r["geom"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, PREDICATE, o)
+
+    final_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    count = sum(
+        1 for r in final_results
+        if str(r["feature"]).strip("<>") == s and
+           str(r["geom"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a GeoSPARQL/SPARQL query returns no results when no match exists."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading GeoSPARQL triples from a .ttl file into the store."""
+    turtle_data = f"""
+    @prefix ex: <http://example.org/> .
+    @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+    ex:featureA a ex:Feature ;
+        geo:hasGeometry ex:geomA .
+
+    ex:geomA a geo:Geometry ;
+        geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and OBJECT in b and POINT_A in b for b in bindings)
+
+
+def test_clear():
+    """Test that clear() removes all geometries from the store."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute() using GeoSPARQL-aware data and queries."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    # INSERT DATA
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(q)
+    assert out is None
+
+    # ASK
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # SELECT
+    q = f"""
+    {PREFIXES}
+    SELECT ?feature WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["feature"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    # DESCRIBE
+    q = f"DESCRIBE <{SUBJECT}>"
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert SUBJECT in desc
+
+    # CONSTRUCT
+    q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature ?p ?o }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature ?p ?o .
+      }}
+    }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert "ex:featureA" in cons
+    assert "ex:geomA" in cons
+
+    # GeoSPARQL SELECT with distance
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+    geo_q = f"""
+    {PREFIXES}
+    SELECT ?geom ?wkt
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        FILTER(?geom = ex:geomB)
+      }}
+    }}
+    """
+    geo_res = store.execute(geo_q)
+    assert isinstance(geo_res, list)
+    assert len(geo_res) == 1
+    assert str(geo_res[0]["geom"]).strip("<>") == f"{EX}geomB"
+    assert POINT_B in str(geo_res[0]["wkt"])
+
+    # DELETE DATA
+    q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    # Re-insert and CLEAR GRAPH
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_add_duplicate_triple():
+    """Test that adding the same triple twice does not create duplicate query results."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    count = sum(
+        1 for r in results
+        if str(r["feature"]).strip("<>") == SUBJECT and
+           str(r["geom"]).strip("<>") == OBJECT
+    )
+    assert count == 1
+
+
+def test_delete_nonexistent_triple():
+    """Test that deleting a triple that does not exist does not raise or affect existing data."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.delete(
+        "http://example.org/nonexistentFeature",
+        PREDICATE,
+        "http://example.org/nonexistentGeom"
+    )
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results) == 1
+    assert str(results[0]["geom"]).strip("<>") == OBJECT
+
+
+def test_named_graph():
+    """Test that queries scoped to the configured graph do not see triples from another named graph."""
+    store = Triplestore("allegrograph", config=config)
+    store.clear()
+
+    other_graph = "http://example.org/other"
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{other_graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results_in_test_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_test_graph) == 0
+
+    results_in_other_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{other_graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_other_graph) == 1
+    row = results_in_other_graph[0]
+    assert str(row["feature"]).strip("<>") == SUBJECT
+    assert str(row["geom"]).strip("<>") == OBJECT

--- a/triplestore/tests_GeoSPARQL/test_graphdb.py
+++ b/triplestore/tests_GeoSPARQL/test_graphdb.py
@@ -647,3 +647,295 @@ def test_named_graph():
     row = results_in_other_graph[0]
     assert str(row["feature"]).strip("<>") == SUBJECT
     assert str(row["geom"]).strip("<>") == OBJECT
+
+
+def test_select_star():
+    """Test SELECT * for GeoSPARQL data: verifies bindings for feature, geometry, and WKT."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    # Insert two point features and one polygon feature
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    # SELECT * with GeoSPARQL FILTER
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT * WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?wkt, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """)
+
+    # Expect 2 results (featureA, featureB)
+    assert len(results) == 2
+
+    expected_rows = [
+        {
+            "feature": f"{EX}featureA",
+            "geom": f"{EX}geomA",
+            "wkt": POINT_A,
+            "boxWKT": POLYGON,
+        },
+        {
+            "feature": f"{EX}featureB",
+            "geom": f"{EX}geomB",
+            "wkt": POINT_B,
+            "boxWKT": POLYGON,
+        },
+    ]
+
+    # Check all expected variables are present
+    for row in results:
+        assert set(row.keys()) == {"feature", "geom", "wkt", "boxWKT"}
+
+    # Check values are valid
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Normalize WKT literals (strip datatype if needed)
+    normalized_results = [
+        {
+            "feature": str(r["feature"]).strip("<>"),
+            "geom": str(r["geom"]).strip("<>"),
+            "wkt": str(r["wkt"]),
+            "boxWKT": str(r["boxWKT"]),
+        }
+        for r in results
+    ]
+
+    # Exact match (order-independent)
+    assert {tuple(sorted(r.items())) for r in normalized_results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # No duplicates
+    assert len(results) == len({tuple(sorted(r.items())) for r in normalized_results})
+
+
+def test_execute_geosparql():
+    """End-to-end test for execute() using several GeoSPARQL spatial functions."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    point_outside = "POINT(23.7600 38.0100)"
+    polygon_overlap = (
+        "POLYGON((23.7350 37.9850, 23.7500 37.9850, "
+        "23.7500 37.9950, 23.7350 37.9950, 23.7350 37.9850))"
+    )
+
+    # INSERT GeoSPARQL dataset
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureOutside a ex:Feature ;
+            geo:hasGeometry ex:geomOutside .
+        ex:geomOutside a geo:Geometry ;
+            geo:asWKT "{point_outside}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+
+        ex:featureOverlap a ex:Feature ;
+            geo:hasGeometry ex:geomOverlap .
+        ex:geomOverlap a geo:Geometry ;
+            geo:asWKT "{polygon_overlap}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(insert_q)
+    assert out is None
+
+    # ASK: base triple exists
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # sfWithin: points A and B are within the polygon
+    within_q = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature NOT IN (ex:featureBox, ex:featureOverlap, ex:featureOutside))
+    }}
+    """
+    within_res = store.execute(within_q)
+    assert isinstance(within_res, list)
+    within_features = {str(r["feature"]).strip("<>") for r in within_res}
+    assert within_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+    }
+
+    # sfContains: polygon contains point A
+    contains_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomA geo:asWKT ?pointWKT .
+        FILTER(geof:sfContains(?boxWKT, ?pointWKT))
+      }}
+    }}
+    """
+    contains_res = store.execute(contains_q)
+    assert isinstance(contains_res, bool)
+    assert contains_res is True
+
+    # sfIntersects: overlapping polygons intersect
+    intersects_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomOverlap geo:asWKT ?overlapWKT .
+        FILTER(geof:sfIntersects(?boxWKT, ?overlapWKT))
+      }}
+    }}
+    """
+    intersects_res = store.execute(intersects_q)
+    assert isinstance(intersects_res, bool)
+    assert intersects_res is True
+
+    # sfDisjoint: outside point is disjoint from the box polygon
+    disjoint_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomOutside geo:asWKT ?outsideWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfDisjoint(?outsideWKT, ?boxWKT))
+      }}
+    }}
+    """
+    disjoint_res = store.execute(disjoint_q)
+    assert isinstance(disjoint_res, bool)
+    assert disjoint_res is True
+
+    # sfEquals: a geometry equals itself
+    equals_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfEquals(?boxWKT, ?boxWKT))
+      }}
+    }}
+    """
+    equals_res = store.execute(equals_q)
+    assert isinstance(equals_res, bool)
+    assert equals_res is True
+
+    # distance: points A and B have positive distance
+    distance_q = f"""
+    {PREFIXES}
+    SELECT ?dist
+    WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomA geo:asWKT ?a .
+        ex:geomB geo:asWKT ?b .
+        BIND(geof:distance(?a, ?b, uom:metre) AS ?dist)
+      }}
+    }}
+    """
+    distance_res = store.execute(distance_q)
+    assert isinstance(distance_res, list)
+    assert len(distance_res) == 1
+    assert "dist" in distance_res[0]
+    assert float(str(distance_res[0]["dist"])) > 0
+
+    # CONSTRUCT on the same dataset
+    construct_q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+    cons = store.execute(construct_q)
+    assert isinstance(cons, str)
+    assert "featureA" in cons
+    assert "geomA" in cons
+    assert "featureBox" in cons
+    assert "geomBox" in cons
+
+    # DELETE one relation and verify removal
+    delete_q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{EX}featureA> <{PREDICATE}> <{EX}geomA> }} }}"
+    del_out = store.execute(delete_q)
+    assert del_out is None
+
+    verify_delete_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    assert store.execute(verify_delete_q) is False
+
+    # CLEAR GRAPH and verify it is empty
+    clear_q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(clear_q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False

--- a/triplestore/tests_GeoSPARQL/test_graphdb.py
+++ b/triplestore/tests_GeoSPARQL/test_graphdb.py
@@ -8,8 +8,11 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local GraphDB instance with REST API access.
 """
 
+import csv
+import json
 import tempfile
 import time
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -46,6 +49,9 @@ WHERE {{
   }}
 }}
 """
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 def is_graphdb_available():
@@ -939,3 +945,553 @@ def test_execute_geosparql():
     clr_out = store.execute(clear_q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def _load_basic_geosparql_dataset(store: Triplestore) -> None:
+    """Load a small GeoSPARQL dataset used by export-oriented tests."""
+    store.clear()
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+
+def test_query_export_json_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_results_json"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_results_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in data
+    ]
+
+    expected_rows = [
+        {"feature": f"{EX}featureA", "geom": f"{EX}geomA", "wkt": POINT_A},
+        {"feature": f"{EX}featureB", "geom": f"{EX}geomB", "wkt": POINT_B},
+        {"feature": f"{EX}featureBox", "geom": f"{EX}geomBox", "wkt": POLYGON},
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_rows} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+
+def test_query_export_csv_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_results_csv"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_results_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in rows
+    ]
+
+    expected_rows = [
+        {"feature": f"{EX}featureA", "geom": f"{EX}geomA", "wkt": POINT_A},
+        {"feature": f"{EX}featureB", "geom": f"{EX}geomB", "wkt": POINT_B},
+        {"feature": f"{EX}featureBox", "geom": f"{EX}geomBox", "wkt": POLYGON},
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_rows} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+
+def test_query_export_csv_with_custom_separator_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV using a custom separator."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_query_export_empty_results_json_geosparql():
+    """Test exporting an empty GeoSPARQL SELECT result set to JSON."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_empty_json"
+    results = store.query(
+        f"""
+        {PREFIXES}
+        SELECT ?feature ?geom ?wkt
+        WHERE {{
+          GRAPH <{GRAPH}> {{
+            <http://example.org/unknown> geo:hasGeometry ?geom .
+            ?geom geo:asWKT ?wkt .
+            BIND(<http://example.org/unknown> AS ?feature)
+          }}
+        }}
+        """,
+        export=True, output_format="json", filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_empty_json.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_rejects_non_select_geosparql():
+    """Test that query() rejects non-SELECT GeoSPARQL/SPARQL queries."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"""
+        {PREFIXES}
+        ASK WHERE {{
+          GRAPH <{GRAPH}> {{
+            ?feature geo:hasGeometry ?geom .
+          }}
+        }}
+        """)
+
+
+def test_query_rejects_unsupported_export_format_geosparql():
+    """Test that query() rejects unsupported export formats for GeoSPARQL SELECT queries."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename=str(TEST_FILES_DIR / "bad_geo_output"))
+
+
+def test_execute_export_select_json_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_json"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+
+def test_execute_export_select_csv_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_csv"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_execute_export_ask_json_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to JSON correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_json"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to TXT correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_txt"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_construct"
+    sparql = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "featureA" in content
+    assert "geomA" in content
+
+
+def test_execute_export_describe_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL DESCRIBE results to Turtle correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_rejects_unsupported_export_format_for_ask_geosparql():
+    """Test that execute() rejects unsupported export formats for GeoSPARQL ASK queries."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_geosparql_ask"))
+
+
+def test_execute_rejects_export_for_update_operations_geosparql():
+    """Test that execute() rejects export for GeoSPARQL update operations."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_geosparql_update"))
+
+
+def test_query_export_geojson_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_results_geojson"
+    results = store.query(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_results_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+    returned_features = {
+        feature["properties"]["feature"].strip("<>")
+        for feature in data["features"]
+    }
+    assert returned_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+        f"{EX}featureBox",
+    }
+
+    for feature in data["features"]:
+        assert feature["type"] == "Feature"
+        assert "geometry" in feature
+        assert "properties" in feature
+        assert feature["geometry"]["type"] in {"Point", "Polygon"}
+
+
+def test_execute_export_geojson_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_geojson"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+
+def test_query_export_geojson_rejects_non_geojson_values():
+    """Test that GeoJSON export fails when the SELECT results contain neither GeoJSON nor WKT."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Cannot export SELECT results as geospatial data"):
+        store.query(sparql, export=True, output_format="geojson", filename=str(TEST_FILES_DIR / "bad_geosparql_geojson"))
+
+
+def test_query_export_empty_results_geojson():
+    """Test exporting an empty GeoSPARQL SELECT result set to GeoJSON."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?wkt
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        BIND(<http://example.org/unknown> AS ?feature)
+      }}
+    }}
+    """
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_empty_geojson"
+    results = store.query(sparql, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_empty_geojson.geojson"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"type": "FeatureCollection", "features": []}
+
+
+def test_query_export_kml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KML correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_results_kml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_results_kml.kml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "<kml" in content
+    assert "<Placemark>" in content
+    assert "<Point>" in content or "<Polygon>" in content
+
+
+def test_query_export_kmz_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_results_kmz"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_results_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_execute_export_kmz_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_kmz"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_query_export_gml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GML correctly."""
+    store = Triplestore("graphdb", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "graphdb_geosparql_results_gml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="gml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "graphdb_geosparql_results_gml.gml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "FeatureCollection" in content
+    assert "featureMember" in content
+    assert "Point" in content or "Polygon" in content

--- a/triplestore/tests_GeoSPARQL/test_graphdb.py
+++ b/triplestore/tests_GeoSPARQL/test_graphdb.py
@@ -1,0 +1,649 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GeoSPARQL tests for the GraphDB backend of the triplestore abstraction layer.
+
+All operations are scoped within the named graph 'http://example.org/test',
+and use a local GraphDB instance with REST API access.
+"""
+
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from triplestore import Triplestore
+from triplestore.utils import detect_graphdb_url
+
+SUBJECT = "http://example.org/featureA"
+PREDICATE = "http://www.opengis.net/ont/geosparql#hasGeometry"
+OBJECT = "http://example.org/geomA"
+
+GRAPH = "http://example.org/test"
+EX = "http://example.org/"
+GEO = "http://www.opengis.net/ont/geosparql#"
+
+POINT_A = "POINT(23.7275 37.9838)"
+POINT_B = "POINT(23.7300 37.9845)"
+POLYGON = "POLYGON((23.7200 37.9800, 23.7400 37.9800, 23.7400 37.9900, 23.7200 37.9900, 23.7200 37.9800))"
+
+PREFIXES = """
+PREFIX ex:   <http://example.org/>
+PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+"""
+
+SPARQL_QUERY = f"""
+{PREFIXES}
+SELECT ?feature ?geom ?wkt
+WHERE {{
+  GRAPH <{GRAPH}> {{
+    ?feature geo:hasGeometry ?geom .
+    ?geom geo:asWKT ?wkt .
+  }}
+}}
+"""
+
+
+def is_graphdb_available():
+    try:
+        url = detect_graphdb_url() + "/repositories"
+        response = requests.get(url, timeout=2)
+    except requests.RequestException:
+        return False
+    else:
+        return response.status_code in {200, 401, 403}
+
+
+pytestmark = pytest.mark.skipif(
+    not is_graphdb_available(),
+    reason="GraphDB instance is not reachable at the configured base_url"
+)
+
+
+config = {
+    "name": f"testns-{int(time.time())}",
+    "auth": None,
+    "graph": GRAPH,
+}
+
+
+def test_add_and_query_triple():
+    """Test adding a geometry triple-pattern and retrieving it via GeoSPARQL/SPARQL."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    query = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query)
+
+    results = store.query(SPARQL_QUERY)
+    bindings = [str(binding) for binding in results]
+
+    assert any(SUBJECT in b and OBJECT in b and POINT_A in b for b in bindings)
+
+
+def test_multiple_triples_query():
+    """Test querying multiple geometries that are within the same polygon."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    query1 = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query1)
+
+    query2 = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """
+    results = store.query(query2)
+    features = [str(row["feature"]).strip("<>") for row in results]
+
+    assert f"{EX}featureA" in features
+    assert f"{EX}featureB" in features
+    assert len(features) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a geometry relation removes it from the store."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    before = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(before) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+
+    after = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(after) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle for a geometry relation."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    initial_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    row = next(iter(initial_results))
+    s = str(row["feature"]).strip("<>")
+    o = str(row["geom"]).strip("<>")
+
+    store.delete(s, PREDICATE, o)
+
+    after_delete = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert not any(
+        str(r["feature"]).strip("<>") == s and
+        str(r["geom"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, PREDICATE, o)
+
+    final_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    count = sum(
+        1 for r in final_results
+        if str(r["feature"]).strip("<>") == s and
+           str(r["geom"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a GeoSPARQL/SPARQL query returns no results when no match exists."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading GeoSPARQL triples from a .ttl file into the store."""
+    turtle_data = f"""
+    @prefix ex: <http://example.org/> .
+    @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+    ex:featureA a ex:Feature ;
+        geo:hasGeometry ex:geomA .
+
+    ex:geomA a geo:Geometry ;
+        geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and OBJECT in b and POINT_A in b for b in bindings)
+
+
+def test_clear():
+    """Test that clear() removes all geometries from the store."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute() using GeoSPARQL-aware data and queries."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    # INSERT DATA
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(q)
+    assert out is None
+
+    # ASK
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # SELECT
+    q = f"""
+    {PREFIXES}
+    SELECT ?feature WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["feature"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    # DESCRIBE
+    q = f"DESCRIBE <{SUBJECT}>"
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert SUBJECT in desc
+
+    # CONSTRUCT
+    q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature ?p ?o }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature ?p ?o .
+      }}
+    }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert "ex:featureA" in cons
+    assert "ex:geomA" in cons
+
+    # GeoSPARQL SELECT with distance
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+    geo_q = f"""
+    {PREFIXES}
+    SELECT ?dist
+    WHERE {{
+      GRAPH <{graph}> {{
+        <{OBJECT}> geo:asWKT ?a .
+        ex:geomB geo:asWKT ?b .
+        BIND(geof:distance(?a, ?b, uom:metre) AS ?dist)
+      }}
+    }}
+    """
+    geo_res = store.execute(geo_q)
+    assert isinstance(geo_res, list)
+    assert len(geo_res) == 1
+    assert float(geo_res[0]["dist"]) > 0.0
+
+    # DELETE DATA
+    q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    # Re-insert and CLEAR GRAPH
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_add_duplicate_triple():
+    """Test that adding the same triple twice does not create duplicate query results."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    count = sum(
+        1 for r in results
+        if str(r["feature"]).strip("<>") == SUBJECT and
+           str(r["geom"]).strip("<>") == OBJECT
+    )
+    assert count == 1
+
+
+def test_delete_nonexistent_triple():
+    """Test that deleting a triple that does not exist does not raise or affect existing data."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.delete(
+        "http://example.org/nonexistentFeature",
+        PREDICATE,
+        "http://example.org/nonexistentGeom"
+    )
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results) == 1
+    assert str(results[0]["geom"]).strip("<>") == OBJECT
+
+
+def test_named_graph():
+    """Test that queries scoped to the configured graph do not see triples from another named graph."""
+    store = Triplestore("graphdb", config=config)
+    store.clear()
+
+    other_graph = "http://example.org/other"
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{other_graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results_in_test_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_test_graph) == 0
+
+    results_in_other_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{other_graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_other_graph) == 1
+    row = results_in_other_graph[0]
+    assert str(row["feature"]).strip("<>") == SUBJECT
+    assert str(row["geom"]).strip("<>") == OBJECT

--- a/triplestore/tests_GeoSPARQL/test_jena.py
+++ b/triplestore/tests_GeoSPARQL/test_jena.py
@@ -8,10 +8,14 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local Jena Fuseki instance with REST API access.
 """
 
+import csv
+import json
 import tempfile
 import time
+import zipfile
 from pathlib import Path
 
+import pytest
 import requests
 from triplestore import Triplestore
 
@@ -44,6 +48,10 @@ WHERE {{
   }}
 }}
 """
+
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 config = {
@@ -948,6 +956,558 @@ def test_execute_geosparql():
     clr_out = store.execute(clear_q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def _load_basic_geosparql_dataset(store: Triplestore) -> None:
+    """Load a small GeoSPARQL dataset used by export-oriented tests."""
+    store.clear()
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+
+def test_query_export_json_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_results_json"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_results_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in data
+    ]
+
+    expected_rows = [
+        {"feature": f"{EX}featureA", "geom": f"{EX}geomA", "wkt": POINT_A},
+        {"feature": f"{EX}featureB", "geom": f"{EX}geomB", "wkt": POINT_B},
+        {"feature": f"{EX}featureBox", "geom": f"{EX}geomBox", "wkt": POLYGON},
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_rows} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+
+def test_query_export_csv_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_results_csv"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_results_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in rows
+    ]
+
+    expected_rows = [
+        {"feature": f"{EX}featureA", "geom": f"{EX}geomA", "wkt": POINT_A},
+        {"feature": f"{EX}featureB", "geom": f"{EX}geomB", "wkt": POINT_B},
+        {"feature": f"{EX}featureBox", "geom": f"{EX}geomBox", "wkt": POLYGON},
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_rows} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+
+def test_query_export_csv_with_custom_separator_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV using a custom separator."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_query_export_empty_results_json_geosparql():
+    """Test exporting an empty GeoSPARQL SELECT result set to JSON."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_empty_json"
+    results = store.query(
+        f"""
+        {PREFIXES}
+        SELECT ?feature ?geom ?wkt
+        WHERE {{
+          GRAPH <{GRAPH}> {{
+            <http://example.org/unknown> geo:hasGeometry ?geom .
+            ?geom geo:asWKT ?wkt .
+            BIND(<http://example.org/unknown> AS ?feature)
+          }}
+        }}
+        """,
+        export=True, output_format="json", filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_empty_json.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_rejects_non_select_geosparql():
+    """Test that query() rejects non-SELECT GeoSPARQL/SPARQL queries."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"""
+        {PREFIXES}
+        ASK WHERE {{
+          GRAPH <{GRAPH}> {{
+            ?feature geo:hasGeometry ?geom .
+          }}
+        }}
+        """)
+
+
+def test_query_rejects_unsupported_export_format_geosparql():
+    """Test that query() rejects unsupported export formats for GeoSPARQL SELECT queries."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename=str(TEST_FILES_DIR / "bad_geo_output"))
+
+
+def test_execute_export_select_json_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_json"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+
+def test_execute_export_select_csv_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_csv"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_execute_export_ask_json_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to JSON correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_json"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to TXT correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_txt"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_construct"
+    sparql = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "featureA" in content
+    assert "geomA" in content
+
+
+def test_execute_export_describe_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL DESCRIBE results to Turtle correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "featureA" in content
+    assert "geomA" in content
+    assert "hasGeometry" in content
+
+
+def test_execute_rejects_unsupported_export_format_for_ask_geosparql():
+    """Test that execute() rejects unsupported export formats for GeoSPARQL ASK queries."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_geosparql_ask"))
+
+
+def test_execute_rejects_export_for_update_operations_geosparql():
+    """Test that execute() rejects export for GeoSPARQL update operations."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_geosparql_update"))
+
+
+def test_query_export_geojson_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_results_geojson"
+    results = store.query(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_results_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+    returned_features = {
+        feature["properties"]["feature"].strip("<>")
+        for feature in data["features"]
+    }
+    assert returned_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+        f"{EX}featureBox",
+    }
+
+    for feature in data["features"]:
+        assert feature["type"] == "Feature"
+        assert "geometry" in feature
+        assert "properties" in feature
+        assert feature["geometry"]["type"] in {"Point", "Polygon"}
+
+
+def test_execute_export_geojson_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_geojson"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+
+def test_query_export_geojson_rejects_non_geojson_values():
+    """Test that GeoJSON export fails when the SELECT results contain neither GeoJSON nor WKT."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Cannot export SELECT results as geospatial data"):
+        store.query(sparql, export=True, output_format="geojson", filename=str(TEST_FILES_DIR / "bad_geosparql_geojson"))
+
+
+def test_query_export_empty_results_geojson():
+    """Test exporting an empty GeoSPARQL SELECT result set to GeoJSON."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?wkt
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        BIND(<http://example.org/unknown> AS ?feature)
+      }}
+    }}
+    """
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_empty_geojson"
+    results = store.query(sparql, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_empty_geojson.geojson"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"type": "FeatureCollection", "features": []}
+
+
+def test_query_export_kml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KML correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_results_kml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_results_kml.kml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "<kml" in content
+    assert "<Placemark>" in content
+    assert "<Point>" in content or "<Polygon>" in content
+
+
+def test_query_export_kmz_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_results_kmz"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_results_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_execute_export_kmz_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_kmz"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_query_export_gml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GML correctly."""
+    store = Triplestore("jena", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "jena_geosparql_results_gml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="gml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "jena_geosparql_results_gml.gml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "FeatureCollection" in content
+    assert "featureMember" in content
+    assert "Point" in content or "Polygon" in content
 
 
 def test_stop_server():

--- a/triplestore/tests_GeoSPARQL/test_jena.py
+++ b/triplestore/tests_GeoSPARQL/test_jena.py
@@ -676,6 +676,280 @@ def test_named_graph():
     assert str(row["geom"]).strip("<>") == OBJECT
 
 
+def test_select_star():
+    """Test SELECT * for GeoSPARQL data: verifies bindings for feature, geometry, and WKT."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    # Insert two point features and one polygon feature
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    # SELECT * with GeoSPARQL FILTER
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT * WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?wkt, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """)
+
+    # Expect 2 results (featureA, featureB)
+    assert len(results) == 2
+
+    expected_rows = [
+        {
+            "feature": f"{EX}featureA",
+            "geom": f"{EX}geomA",
+            "wkt": POINT_A,
+            "boxWKT": POLYGON,
+        },
+        {
+            "feature": f"{EX}featureB",
+            "geom": f"{EX}geomB",
+            "wkt": POINT_B,
+            "boxWKT": POLYGON,
+        },
+    ]
+
+    # Check all expected variables are present
+    for row in results:
+        assert set(row.keys()) == {"feature", "geom", "wkt", "boxWKT"}
+
+    # Check values are valid
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Normalize WKT literals (strip datatype if needed)
+    normalized_results = [
+        {
+            "feature": str(r["feature"]).strip("<>"),
+            "geom": str(r["geom"]).strip("<>"),
+            "wkt": str(r["wkt"]),
+            "boxWKT": str(r["boxWKT"]),
+        }
+        for r in results
+    ]
+
+    # Exact match (order-independent)
+    assert {tuple(sorted(r.items())) for r in normalized_results} == \
+           {tuple(sorted(r.items())) for r in expected_rows}
+
+    # No duplicates
+    assert len(results) == len({tuple(sorted(r.items())) for r in normalized_results})
+
+
+def test_execute_geosparql():
+    """End-to-end test for execute() using several GeoSPARQL spatial functions."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    point_outside = "POINT(23.7600 38.0100)"
+    polygon_overlap = (
+        "POLYGON((23.7350 37.9850, 23.7500 37.9850, "
+        "23.7500 37.9950, 23.7350 37.9950, 23.7350 37.9850))"
+    )
+
+    # INSERT GeoSPARQL dataset
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureOutside a ex:Feature ;
+            geo:hasGeometry ex:geomOutside .
+        ex:geomOutside a geo:Geometry ;
+            geo:asWKT "{point_outside}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+
+        ex:featureOverlap a ex:Feature ;
+            geo:hasGeometry ex:geomOverlap .
+        ex:geomOverlap a geo:Geometry ;
+            geo:asWKT "{polygon_overlap}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(insert_q)
+    assert out is None
+
+    # ASK: base triple exists
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # sfWithin: points A and B are within the polygon
+    within_q = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature NOT IN (ex:featureBox, ex:featureOverlap, ex:featureOutside))
+    }}
+    """
+    within_res = store.execute(within_q)
+    assert isinstance(within_res, list)
+    within_features = {str(r["feature"]).strip("<>") for r in within_res}
+    assert within_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+    }
+
+    # sfContains: polygon contains point A
+    contains_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomA geo:asWKT ?pointWKT .
+        FILTER(geof:sfContains(?boxWKT, ?pointWKT))
+      }}
+    }}
+    """
+    contains_res = store.execute(contains_q)
+    assert isinstance(contains_res, bool)
+    assert contains_res is True
+
+    # sfIntersects: overlapping polygons intersect
+    intersects_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomOverlap geo:asWKT ?overlapWKT .
+        FILTER(geof:sfIntersects(?boxWKT, ?overlapWKT))
+      }}
+    }}
+    """
+    intersects_res = store.execute(intersects_q)
+    assert isinstance(intersects_res, bool)
+    assert intersects_res is True
+
+    # sfDisjoint: outside point is disjoint from the box polygon
+    disjoint_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomOutside geo:asWKT ?outsideWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfDisjoint(?outsideWKT, ?boxWKT))
+      }}
+    }}
+    """
+    disjoint_res = store.execute(disjoint_q)
+    assert isinstance(disjoint_res, bool)
+    assert disjoint_res is True
+
+    # sfEquals: a geometry equals itself
+    equals_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfEquals(?boxWKT, ?boxWKT))
+      }}
+    }}
+    """
+    equals_res = store.execute(equals_q)
+    assert isinstance(equals_res, bool)
+    assert equals_res is True
+
+    # CONSTRUCT on the same dataset
+    construct_q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+    cons = store.execute(construct_q)
+    assert isinstance(cons, str)
+    assert "featureA" in cons
+    assert "geomA" in cons
+    assert "featureBox" in cons
+    assert "geomBox" in cons
+
+    # DELETE one relation and verify removal
+    delete_q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{EX}featureA> <{PREDICATE}> <{EX}geomA> }} }}"
+    del_out = store.execute(delete_q)
+    assert del_out is None
+
+    verify_delete_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    assert store.execute(verify_delete_q) is False
+
+    # CLEAR GRAPH and verify it is empty
+    clear_q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(clear_q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
 def test_stop_server():
     """Test that stop_server() terminates a running Fuseki instance."""
     store = Triplestore("jena", config=config)

--- a/triplestore/tests_GeoSPARQL/test_jena.py
+++ b/triplestore/tests_GeoSPARQL/test_jena.py
@@ -1,0 +1,692 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GeoSPARQL tests for the Apache Jena backend of the triplestore abstraction layer.
+
+All operations are scoped within the named graph 'http://example.org/test',
+and use a local Jena Fuseki instance with REST API access.
+"""
+
+import tempfile
+import time
+from pathlib import Path
+
+import requests
+from triplestore import Triplestore
+
+SUBJECT = "http://example.org/featureA"
+PREDICATE = "http://www.opengis.net/ont/geosparql#hasGeometry"
+OBJECT = "http://example.org/geomA"
+
+GRAPH = "http://example.org/test"
+EX = "http://example.org/"
+GEO = "http://www.opengis.net/ont/geosparql#"
+
+POINT_A = "POINT(23.7275 37.9838)"
+POINT_B = "POINT(23.7300 37.9845)"
+POLYGON = "POLYGON((23.7200 37.9800, 23.7400 37.9800, 23.7400 37.9900, 23.7200 37.9900, 23.7200 37.9800))"
+
+PREFIXES = """
+PREFIX ex:   <http://example.org/>
+PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+"""
+
+SPARQL_QUERY = f"""
+{PREFIXES}
+SELECT ?feature ?geom ?wkt
+WHERE {{
+  GRAPH <{GRAPH}> {{
+    ?feature geo:hasGeometry ?geom .
+    ?geom geo:asWKT ?wkt .
+  }}
+}}
+"""
+
+
+config = {
+    "base_url": "http://localhost:3030",
+    "name": f"testns-{int(time.time())}",
+    "auth": None,
+    "graph": GRAPH,
+}
+
+
+def test_add_and_query_triple():
+    """Test adding a geometry triple-pattern and retrieving it via GeoSPARQL/SPARQL."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    query = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query)
+
+    results = store.query(SPARQL_QUERY)
+    bindings = [str(binding) for binding in results]
+
+    assert any(SUBJECT in b and OBJECT in b and POINT_A in b for b in bindings)
+
+
+def test_multiple_triples_query():
+    """Test querying multiple geometries that are within the same polygon."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    query1 = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query1)
+
+    query2 = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """
+    results = store.query(query2)
+    features = [str(row["feature"]).strip("<>") for row in results]
+
+    assert f"{EX}featureA" in features
+    assert f"{EX}featureB" in features
+    assert len(features) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a geometry relation removes it from the store."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    before = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(before) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+
+    after = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(after) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle for a geometry relation."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    initial_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    row = next(iter(initial_results))
+    s = str(row["feature"]).strip("<>")
+    o = str(row["geom"]).strip("<>")
+
+    store.delete(s, PREDICATE, o)
+
+    after_delete = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert not any(
+        str(r["feature"]).strip("<>") == s and
+        str(r["geom"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, PREDICATE, o)
+
+    final_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    count = sum(
+        1 for r in final_results
+        if str(r["feature"]).strip("<>") == s and
+           str(r["geom"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a GeoSPARQL/SPARQL query returns no results when no match exists."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading GeoSPARQL triples from a .ttl file into the store."""
+    turtle_data = f"""
+    @prefix ex: <http://example.org/> .
+    @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+    ex:featureA a ex:Feature ;
+        geo:hasGeometry ex:geomA .
+
+    ex:geomA a geo:Geometry ;
+        geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    store = Triplestore("jena", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(SUBJECT in b and OBJECT in b and POINT_A in b for b in bindings)
+
+
+def test_clear():
+    """Test that clear() removes all geometries from the store."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute() using GeoSPARQL-aware data and queries."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    # INSERT DATA
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(q)
+    assert out is None
+
+    # ASK
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # SELECT
+    q = f"""
+    {PREFIXES}
+    SELECT ?feature WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["feature"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    # DESCRIBE
+    q = f"DESCRIBE <{SUBJECT}>"
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert "featureA" in desc
+    assert "geo:hasGeometry" in desc or "hasGeometry" in desc
+
+    # CONSTRUCT
+    q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature ?p ?o }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature ?p ?o .
+      }}
+    }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert "ex:featureA" in cons
+    assert "ex:geomA" in cons
+
+    # GeoSPARQL SELECT with distance
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+    geo_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{OBJECT}> geo:asWKT ?a .
+        ex:geomB geo:asWKT ?b .
+        FILTER(geof:sfIntersects(?a, ?b))
+      }}
+    }}
+    """
+    geo_res = store.execute(geo_q)
+    assert isinstance(geo_res, bool)
+
+    # GeoSPARQL tests: sfWithin and sfIntersects
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featurePoly a ex:Feature ;
+            geo:hasGeometry ex:geomPoly .
+        ex:geomPoly a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+    within_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{OBJECT}> geo:asWKT ?pointWKT .
+        ex:geomPoly geo:asWKT ?polyWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?polyWKT))
+      }}
+    }}
+    """
+    within_res = store.execute(within_q)
+    assert isinstance(within_res, bool)
+    assert within_res is True
+
+    intersects_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomB geo:asWKT ?pointWKT .
+        ex:geomPoly geo:asWKT ?polyWKT .
+        FILTER(geof:sfIntersects(?pointWKT, ?polyWKT))
+      }}
+    }}
+    """
+    intersects_res = store.execute(intersects_q)
+    assert isinstance(intersects_res, bool)
+    assert intersects_res is True
+
+    # DELETE DATA
+    q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    # Re-insert and CLEAR GRAPH
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_add_duplicate_triple():
+    """Test that adding the same triple twice does not create duplicate query results."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    count = sum(
+        1 for r in results
+        if str(r["feature"]).strip("<>") == SUBJECT and
+           str(r["geom"]).strip("<>") == OBJECT
+    )
+    assert count == 1
+
+
+def test_delete_nonexistent_triple():
+    """Test that deleting a triple that does not exist does not raise or affect existing data."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.delete(
+        "http://example.org/nonexistentFeature",
+        PREDICATE,
+        "http://example.org/nonexistentGeom"
+    )
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results) == 1
+    assert str(results[0]["geom"]).strip("<>") == OBJECT
+
+
+def test_named_graph():
+    """Test that queries scoped to the configured graph do not see triples from another named graph."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    other_graph = "http://example.org/other"
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{other_graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results_in_test_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_test_graph) == 0
+
+    results_in_other_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{other_graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_other_graph) == 1
+    row = results_in_other_graph[0]
+    assert str(row["feature"]).strip("<>") == SUBJECT
+    assert str(row["geom"]).strip("<>") == OBJECT
+
+
+def test_stop_server():
+    """Test that stop_server() terminates a running Fuseki instance."""
+    store = Triplestore("jena", config=config)
+    store.clear()
+
+    result = store.stop_server()
+
+    assert result is True
+
+    try:
+        r = requests.get(f"{config['base_url']}/$/ping", timeout=2)
+        assert r.status_code != 200
+    except requests.RequestException:
+        pass

--- a/triplestore/tests_GeoSPARQL/test_qlever.py
+++ b/triplestore/tests_GeoSPARQL/test_qlever.py
@@ -8,11 +8,15 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local QLever instance with HTTP API access.
 """
 
+import csv
+import json
 import tempfile
+import zipfile
 from pathlib import Path
 
 import pytest
 import requests
+from shapely import wkt as shapely_wkt
 from triplestore import Triplestore
 
 SUBJECT = "http://example.org/featureA"
@@ -44,6 +48,9 @@ WHERE {{
   }}
 }}
 """
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 WORKDIR = (Path(__file__).resolve().parent / "qlever-test-demo").resolve()
 
@@ -899,6 +906,566 @@ def test_execute_geosparql():
     clr_out = store.execute(clear_q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def _load_basic_geosparql_dataset(store: Triplestore) -> None:
+    """Load a small GeoSPARQL dataset used by export-oriented tests."""
+    store.clear()
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+
+def _same_wkt_geometry(left: str, right: str) -> bool:
+    return shapely_wkt.loads(left).equals(shapely_wkt.loads(right))
+
+
+def test_query_export_json_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_results_json"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_results_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in data
+    ]
+
+    expected_rows = {
+        f"{EX}featureA": {"geom": f"{EX}geomA", "wkt": POINT_A},
+        f"{EX}featureB": {"geom": f"{EX}geomB", "wkt": POINT_B},
+        f"{EX}featureBox": {"geom": f"{EX}geomBox", "wkt": POLYGON},
+    }
+
+    assert len(normalized_rows) == 3
+
+    for row in normalized_rows:
+        expected = expected_rows[row["feature"]]
+        assert row["geom"] == expected["geom"]
+        assert _same_wkt_geometry(row["wkt"], expected["wkt"])
+
+
+def test_query_export_csv_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_results_csv"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_results_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in rows
+    ]
+
+    expected_rows = {
+        f"{EX}featureA": {"geom": f"{EX}geomA", "wkt": POINT_A},
+        f"{EX}featureB": {"geom": f"{EX}geomB", "wkt": POINT_B},
+        f"{EX}featureBox": {"geom": f"{EX}geomBox", "wkt": POLYGON},
+    }
+
+    assert len(normalized_rows) == 3
+
+    for row in normalized_rows:
+        expected = expected_rows[row["feature"]]
+        assert row["geom"] == expected["geom"]
+        assert _same_wkt_geometry(row["wkt"], expected["wkt"])
+
+
+def test_query_export_csv_with_custom_separator_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV using a custom separator."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_query_export_empty_results_json_geosparql():
+    """Test exporting an empty GeoSPARQL SELECT result set to JSON."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_empty_json"
+    results = store.query(
+        f"""
+        {PREFIXES}
+        SELECT ?feature ?geom ?wkt
+        WHERE {{
+          GRAPH <{GRAPH}> {{
+            <http://example.org/unknown> geo:hasGeometry ?geom .
+            ?geom geo:asWKT ?wkt .
+            BIND(<http://example.org/unknown> AS ?feature)
+          }}
+        }}
+        """,
+        export=True, output_format="json", filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_empty_json.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_rejects_non_select_geosparql():
+    """Test that query() rejects non-SELECT GeoSPARQL/SPARQL queries."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"""
+        {PREFIXES}
+        ASK WHERE {{
+          GRAPH <{GRAPH}> {{
+            ?feature geo:hasGeometry ?geom .
+          }}
+        }}
+        """)
+
+
+def test_query_rejects_unsupported_export_format_geosparql():
+    """Test that query() rejects unsupported export formats for GeoSPARQL SELECT queries."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename=str(TEST_FILES_DIR / "bad_geo_output"))
+
+
+def test_execute_export_select_json_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_json"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+
+def test_execute_export_select_csv_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_csv"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_execute_export_ask_json_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to JSON correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_json"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to TXT correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_txt"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_construct"
+    sparql = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "featureA" in content
+    assert "geomA" in content
+
+
+def test_execute_export_describe_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL DESCRIBE results to Turtle correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_rejects_unsupported_export_format_for_ask_geosparql():
+    """Test that execute() rejects unsupported export formats for GeoSPARQL ASK queries."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_geosparql_ask"))
+
+
+def test_execute_rejects_export_for_update_operations_geosparql():
+    """Test that execute() rejects export for GeoSPARQL update operations."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_geosparql_update"))
+
+
+def test_query_export_geojson_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_results_geojson"
+    results = store.query(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_results_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+    returned_features = {
+        feature["properties"]["feature"].strip("<>")
+        for feature in data["features"]
+    }
+    assert returned_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+        f"{EX}featureBox",
+    }
+
+    for feature in data["features"]:
+        assert feature["type"] == "Feature"
+        assert "geometry" in feature
+        assert "properties" in feature
+        assert feature["geometry"]["type"] in {"Point", "Polygon"}
+
+
+def test_execute_export_geojson_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_geojson"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+
+def test_query_export_geojson_rejects_non_geojson_values():
+    """Test that GeoJSON export fails when the SELECT results contain neither GeoJSON nor WKT."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Cannot export SELECT results as geospatial data"):
+        store.query(sparql, export=True, output_format="geojson", filename=str(TEST_FILES_DIR / "bad_geosparql_geojson"))
+
+
+def test_query_export_empty_results_geojson():
+    """Test exporting an empty GeoSPARQL SELECT result set to GeoJSON."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?wkt
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        BIND(<http://example.org/unknown> AS ?feature)
+      }}
+    }}
+    """
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_empty_geojson"
+    results = store.query(sparql, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_empty_geojson.geojson"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"type": "FeatureCollection", "features": []}
+
+
+def test_query_export_kml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KML correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_results_kml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_results_kml.kml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "<kml" in content
+    assert "<Placemark>" in content
+    assert "<Point>" in content or "<Polygon>" in content
+
+
+def test_query_export_kmz_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_results_kmz"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_results_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_execute_export_kmz_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_kmz"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_query_export_gml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GML correctly."""
+    store = Triplestore("qlever", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "qlever_geosparql_results_gml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="gml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "qlever_geosparql_results_gml.gml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "FeatureCollection" in content
+    assert "featureMember" in content
+    assert "Point" in content or "Polygon" in content
 
 
 def test_stop_server():

--- a/triplestore/tests_GeoSPARQL/test_qlever.py
+++ b/triplestore/tests_GeoSPARQL/test_qlever.py
@@ -640,6 +640,267 @@ def test_named_graph():
     assert str(row["geom"]).strip("<>") == OBJECT
 
 
+def test_select_star():
+    """Test SELECT * for GeoSPARQL data: verifies bindings for feature, geometry, and WKT."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    # Insert two point features and one polygon feature
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    # SELECT * with GeoSPARQL FILTER
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT * WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?wkt, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """)
+
+    # Expect 2 results (featureA, featureB)
+    assert len(results) == 2
+
+    expected_rows = [
+        {
+            "feature": f"{EX}featureA",
+            "geom": f"{EX}geomA",
+            "wkt": POINT_A,
+            "boxWKT": POLYGON,
+        },
+        {
+            "feature": f"{EX}featureB",
+            "geom": f"{EX}geomB",
+            "wkt": POINT_B,
+            "boxWKT": POLYGON,
+        },
+    ]
+
+    # Check all expected variables are present
+    for row in results:
+        assert set(row.keys()) == {"feature", "geom", "wkt", "boxWKT"}
+
+    # Check values are valid
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    # Normalize WKT literals (strip datatype if needed)
+    normalized_results = [
+        {
+            "feature": str(r["feature"]).strip("<>"),
+            "geom": str(r["geom"]).strip("<>"),
+            "wkt": str(r["wkt"]),
+            "boxWKT": str(r["boxWKT"]),
+        }
+        for r in results
+    ]
+
+    # No duplicates
+    assert len(results) == len({tuple(sorted(r.items())) for r in normalized_results})
+
+
+def test_execute_geosparql():
+    """End-to-end test for execute() using several GeoSPARQL spatial functions."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    point_outside = "POINT(23.7600 38.0100)"
+    polygon_overlap = (
+        "POLYGON((23.7350 37.9850, 23.7500 37.9850, "
+        "23.7500 37.9950, 23.7350 37.9950, 23.7350 37.9850))"
+    )
+
+    # INSERT GeoSPARQL dataset
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureOutside a ex:Feature ;
+            geo:hasGeometry ex:geomOutside .
+        ex:geomOutside a geo:Geometry ;
+            geo:asWKT "{point_outside}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+
+        ex:featureBoxCopy a ex:Feature ;
+            geo:hasGeometry ex:geomBoxCopy .
+        ex:geomBoxCopy a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+
+        ex:featureOverlap a ex:Feature ;
+            geo:hasGeometry ex:geomOverlap .
+        ex:geomOverlap a geo:Geometry ;
+            geo:asWKT "{polygon_overlap}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(insert_q)
+    assert out is None
+
+    # ASK: base triple exists
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # sfWithin: points A and B are within the polygon
+    within_q = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature NOT IN (ex:featureBox, ex:featureBoxCopy, ex:featureOverlap, ex:featureOutside))
+    }}
+    """
+    within_res = store.execute(within_q)
+    assert isinstance(within_res, list)
+    within_features = {str(r["feature"]).strip("<>") for r in within_res}
+    assert within_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+    }
+
+    # sfContains: polygon contains point A
+    contains_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomA geo:asWKT ?pointWKT .
+        FILTER(geof:sfContains(?boxWKT, ?pointWKT))
+      }}
+    }}
+    """
+    contains_res = store.execute(contains_q)
+    assert isinstance(contains_res, bool)
+    assert contains_res is True
+
+    # sfIntersects: overlapping polygons intersect
+    intersects_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomOverlap geo:asWKT ?overlapWKT .
+        FILTER(geof:sfIntersects(?boxWKT, ?overlapWKT))
+      }}
+    }}
+    """
+    intersects_res = store.execute(intersects_q)
+    assert isinstance(intersects_res, bool)
+    assert intersects_res is True
+
+    # sfEquals: a geometry equals itself
+    equals_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomBoxCopy geo:asWKT ?boxCopyWKT .
+        FILTER(geof:sfEquals(?boxWKT, ?boxCopyWKT))
+      }}
+    }}
+    """
+    equals_res = store.execute(equals_q)
+    assert isinstance(equals_res, bool)
+    assert equals_res is True
+
+    # CONSTRUCT on the same dataset
+    construct_q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+    cons = store.execute(construct_q)
+    assert isinstance(cons, str)
+    assert "featureA" in cons
+    assert "geomA" in cons
+    assert "featureBox" in cons
+    assert "geomBox" in cons
+
+    # DELETE one relation and verify removal
+    delete_q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{EX}featureA> <{PREDICATE}> <{EX}geomA> }} }}"
+    del_out = store.execute(delete_q)
+    assert del_out is None
+
+    verify_delete_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    assert store.execute(verify_delete_q) is False
+
+    # CLEAR GRAPH and verify it is empty
+    clear_q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(clear_q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
 def test_stop_server():
     store = Triplestore("qlever", config=config)
     store.stop_server()

--- a/triplestore/tests_GeoSPARQL/test_qlever.py
+++ b/triplestore/tests_GeoSPARQL/test_qlever.py
@@ -1,0 +1,648 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GeoSPARQL tests for the QLever backend of the triplestore abstraction layer.
+
+All operations are scoped within the named graph 'http://example.org/test',
+and use a local QLever instance with HTTP API access.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import requests
+from triplestore import Triplestore
+
+SUBJECT = "http://example.org/featureA"
+PREDICATE = "http://www.opengis.net/ont/geosparql#hasGeometry"
+OBJECT = "http://example.org/geomA"
+
+GRAPH = "http://example.org/test"
+EX = "http://example.org/"
+GEO = "http://www.opengis.net/ont/geosparql#"
+
+POINT_A = "POINT(23.7275 37.9838)"
+POINT_B = "POINT(23.7300 37.9845)"
+POLYGON = "POLYGON((23.7200 37.9800, 23.7400 37.9800, 23.7400 37.9900, 23.7200 37.9900, 23.7200 37.9800))"
+
+PREFIXES = """
+PREFIX ex:   <http://example.org/>
+PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+"""
+
+SPARQL_QUERY = f"""
+{PREFIXES}
+SELECT ?feature ?geom ?wkt
+WHERE {{
+  GRAPH <{GRAPH}> {{
+    ?feature geo:hasGeometry ?geom .
+    ?geom geo:asWKT ?wkt .
+  }}
+}}
+"""
+
+WORKDIR = (Path(__file__).resolve().parent / "qlever-test-demo").resolve()
+
+config = {
+    "base_url": "http://localhost:7019",
+    "graph": GRAPH,
+    "dataset": "olympics",
+    "working_directory": str(WORKDIR),
+}
+
+
+def test_initialize_server():
+    store = Triplestore("qlever", config=config)
+
+    response = requests.get(config["base_url"], timeout=5)
+    assert response.status_code in {200, 400, 404, 405}
+
+
+def test_add_and_query_triple():
+    """Test adding a geometry triple-pattern and retrieving it via GeoSPARQL/SPARQL."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    query = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query)
+
+    results = store.query(SPARQL_QUERY)
+    bindings = [str(binding) for binding in results]
+
+    assert any(row["feature"] == SUBJECT and row["geom"] == OBJECT and "POINT(" in row["wkt"] for row in results)
+
+
+def test_multiple_triples_query():
+    """Test querying multiple geometries that are within the same polygon."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    query1 = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query1)
+
+    query2 = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """
+    results = store.query(query2)
+    features = [str(row["feature"]).strip("<>") for row in results]
+
+    assert f"{EX}featureA" in features
+    assert f"{EX}featureB" in features
+    assert len(features) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a geometry relation removes it from the store."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    before = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(before) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+
+    after = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(after) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle for a geometry relation."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    initial_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    row = next(iter(initial_results))
+    s = str(row["feature"]).strip("<>")
+    o = str(row["geom"]).strip("<>")
+
+    store.delete(s, PREDICATE, o)
+
+    after_delete = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert not any(
+        str(r["feature"]).strip("<>") == s and
+        str(r["geom"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, PREDICATE, o)
+
+    final_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    count = sum(
+        1 for r in final_results
+        if str(r["feature"]).strip("<>") == s and
+           str(r["geom"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a GeoSPARQL/SPARQL query returns no results when no match exists."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading GeoSPARQL triples from a .ttl file into the store."""
+    turtle_data = f"""
+    @prefix ex: <http://example.org/> .
+    @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+    ex:featureA a ex:Feature ;
+        geo:hasGeometry ex:geomA .
+
+    ex:geomA a geo:Geometry ;
+        geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    store = Triplestore("qlever", config=config)
+    store.clear()
+    store.load(tmp_path)
+
+    results = store.query(SPARQL_QUERY)
+    Path(tmp_path).unlink()
+
+    bindings = [str(binding) for binding in results]
+    assert any(row["feature"] == SUBJECT and row["geom"] == OBJECT and "POINT(" in row["wkt"] for row in results)
+
+
+def test_clear():
+    """Test that clear() removes all geometries from the store."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute() using GeoSPARQL-aware data and queries."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    # INSERT DATA
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(q)
+    assert out is None
+
+    # ASK
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    # SELECT
+    q = f"""
+    {PREFIXES}
+    SELECT ?feature WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["feature"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    # DESCRIBE
+    q = f"DESCRIBE <{SUBJECT}>"
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert SUBJECT in desc
+
+    # CONSTRUCT
+    q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature ?p ?o }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature ?p ?o .
+      }}
+    }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert SUBJECT in cons
+    assert OBJECT in cons
+
+    # GeoSPARQL SELECT with distance
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+    geo_q = f"""
+    {PREFIXES}
+    SELECT ?dist
+    WHERE {{
+      GRAPH <{graph}> {{
+        <{OBJECT}> geo:asWKT ?a .
+        ex:geomB geo:asWKT ?b .
+        BIND(geof:distance(?a, ?b) AS ?dist)
+      }}
+    }}
+  """
+    geo_res = store.execute(geo_q)
+    assert isinstance(geo_res, list)
+    assert len(geo_res) == 1
+    assert float(geo_res[0]["dist"]) > 0.0
+
+    # DELETE DATA
+    q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    # Re-insert and CLEAR GRAPH
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_add_duplicate_triple():
+    """Test that adding the same triple twice does not create duplicate query results."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    count = sum(
+        1 for r in results
+        if str(r["feature"]).strip("<>") == SUBJECT and
+           str(r["geom"]).strip("<>") == OBJECT
+    )
+    assert count == 1
+
+
+def test_delete_nonexistent_triple():
+    """Test that deleting a triple that does not exist does not raise or affect existing data."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.delete(
+        "http://example.org/nonexistentFeature",
+        PREDICATE,
+        "http://example.org/nonexistentGeom"
+    )
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results) == 1
+    assert str(results[0]["geom"]).strip("<>") == OBJECT
+
+
+def test_named_graph():
+    """Test that queries scoped to the configured graph do not see triples from another named graph."""
+    store = Triplestore("qlever", config=config)
+    store.clear()
+
+    other_graph = "http://example.org/other"
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{other_graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results_in_test_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_test_graph) == 0
+
+    results_in_other_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{other_graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_other_graph) == 1
+    row = results_in_other_graph[0]
+    assert str(row["feature"]).strip("<>") == SUBJECT
+    assert str(row["geom"]).strip("<>") == OBJECT
+
+
+def test_stop_server():
+    store = Triplestore("qlever", config=config)
+    store.stop_server()
+
+    with pytest.raises(requests.RequestException):
+        requests.get(config["base_url"], timeout=2)

--- a/triplestore/tests_GeoSPARQL/test_rdf4j.py
+++ b/triplestore/tests_GeoSPARQL/test_rdf4j.py
@@ -1,0 +1,918 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GeoSPARQL tests for the RDF4J backend of the triplestore abstraction layer.
+
+All operations are scoped within the named graph 'http://example.org/test',
+and use a local RDF4J instance with REST API access.
+"""
+
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from triplestore import Triplestore
+
+BASE_URL = "http://localhost:8080/rdf4j-server"
+
+SUBJECT = "http://example.org/featureA"
+PREDICATE = "http://www.opengis.net/ont/geosparql#hasGeometry"
+OBJECT = "http://example.org/geomA"
+
+GRAPH = "http://example.org/test"
+EX = "http://example.org/"
+GEO = "http://www.opengis.net/ont/geosparql#"
+
+POINT_A = "POINT(23.7275 37.9838)"
+POINT_B = "POINT(23.7300 37.9845)"
+POLYGON = "POLYGON((23.7200 37.9800, 23.7400 37.9800, 23.7400 37.9900, 23.7200 37.9900, 23.7200 37.9800))"
+
+PREFIXES = """
+PREFIX ex:   <http://example.org/>
+PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+"""
+
+SPARQL_QUERY = f"""
+{PREFIXES}
+SELECT ?feature ?geom ?wkt
+WHERE {{
+  GRAPH <{GRAPH}> {{
+    ?feature geo:hasGeometry ?geom .
+    ?geom geo:asWKT ?wkt .
+  }}
+}}
+"""
+
+
+def is_rdf4j_available() -> bool:
+    try:
+        response = requests.get(f"{BASE_URL}/repositories", timeout=2)
+    except requests.RequestException:
+        return False
+    else:
+        return response.status_code == 200
+
+
+pytestmark = pytest.mark.skipif(
+    not is_rdf4j_available(),
+    reason="RDF4J instance is not reachable at the configured base_url",
+)
+
+
+config = {
+    "name": f"testns-{int(time.time())}",
+    "base_url": BASE_URL,
+    "auth": None,
+    "graph": GRAPH,
+    "store_type": "native",
+}
+
+
+def test_add_and_query_triple():
+    """Test adding a geometry triple-pattern and retrieving it via GeoSPARQL/SPARQL."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    query = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query)
+
+    results = store.query(SPARQL_QUERY)
+    bindings = [str(binding) for binding in results]
+
+    assert any(SUBJECT in b and OBJECT in b and POINT_A in b for b in bindings)
+
+
+def test_multiple_triples_query():
+    """Test querying multiple geometries that are within the same polygon."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    query1 = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query1)
+
+    query2 = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """
+    results = store.query(query2)
+    features = [str(row["feature"]).strip("<>") for row in results]
+
+    assert f"{EX}featureA" in features
+    assert f"{EX}featureB" in features
+    assert len(features) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a geometry relation removes it from the store."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    before = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(before) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+
+    after = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(after) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle for a geometry relation."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    initial_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    row = next(iter(initial_results))
+    s = str(row["feature"]).strip("<>")
+    o = str(row["geom"]).strip("<>")
+
+    store.delete(s, PREDICATE, o)
+
+    after_delete = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert not any(
+        str(r["feature"]).strip("<>") == s and
+        str(r["geom"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, PREDICATE, o)
+
+    final_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    count = sum(
+        1 for r in final_results
+        if str(r["feature"]).strip("<>") == s and
+           str(r["geom"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a GeoSPARQL/SPARQL query returns no results when no match exists."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading GeoSPARQL triples from a .ttl file into the store."""
+    turtle_data = f"""
+    @prefix ex: <http://example.org/> .
+    @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+    ex:featureA a ex:Feature ;
+        geo:hasGeometry ex:geomA .
+
+    ex:geomA a geo:Geometry ;
+        geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    try:
+        store = Triplestore("rdf4j", config=config)
+        store.clear()
+        store.load(tmp_path)
+
+        results = store.query(SPARQL_QUERY)
+        bindings = [str(binding) for binding in results]
+        assert any(SUBJECT in b and OBJECT in b and POINT_A in b for b in bindings)
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def test_clear():
+    """Test that clear() removes all geometries from the store."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute() using GeoSPARQL-aware data and queries."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(q)
+    assert out is None
+
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    q = f"""
+    {PREFIXES}
+    SELECT ?feature WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["feature"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    q = f"DESCRIBE <{SUBJECT}>"
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert SUBJECT in desc
+
+    q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature ?p ?o }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature ?p ?o .
+      }}
+    }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert "featureA" in cons
+    assert "geomA" in cons
+
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+    geo_q = f"""
+    {PREFIXES}
+    SELECT ?dist
+    WHERE {{
+      GRAPH <{graph}> {{
+        <{OBJECT}> geo:asWKT ?a .
+        ex:geomB geo:asWKT ?b .
+        BIND(geof:distance(?a, ?b, uom:metre) AS ?dist)
+      }}
+    }}
+    """
+    geo_res = store.execute(geo_q)
+    assert isinstance(geo_res, list)
+    assert len(geo_res) == 1
+    assert float(geo_res[0]["dist"]) > 0.0
+
+    q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_add_duplicate_triple():
+    """Test that adding the same triple twice does not create duplicate query results."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    count = sum(
+        1 for r in results
+        if str(r["feature"]).strip("<>") == SUBJECT and
+           str(r["geom"]).strip("<>") == OBJECT
+    )
+    assert count == 1
+
+
+def test_delete_nonexistent_triple():
+    """Test that deleting a triple that does not exist does not raise or affect existing data."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.delete(
+        "http://example.org/nonexistentFeature",
+        PREDICATE,
+        "http://example.org/nonexistentGeom",
+    )
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results) == 1
+    assert str(results[0]["geom"]).strip("<>") == OBJECT
+
+
+def test_named_graph():
+    """Test that queries scoped to the configured graph do not see triples from another named graph."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    other_graph = "http://example.org/other"
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{other_graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results_in_test_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_test_graph) == 0
+
+    results_in_other_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{other_graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_other_graph) == 1
+    row = results_in_other_graph[0]
+    assert str(row["feature"]).strip("<>") == SUBJECT
+    assert str(row["geom"]).strip("<>") == OBJECT
+
+
+def test_select_star():
+    """Test SELECT * for GeoSPARQL data: verifies bindings for feature, geometry, and WKT."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT * WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?wkt, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """)
+
+    assert len(results) == 2
+
+    expected_rows = [
+        {
+            "feature": f"{EX}featureA",
+            "geom": f"{EX}geomA",
+            "wkt": POINT_A,
+            "boxWKT": POLYGON,
+        },
+        {
+            "feature": f"{EX}featureB",
+            "geom": f"{EX}geomB",
+            "wkt": POINT_B,
+            "boxWKT": POLYGON,
+        },
+    ]
+
+    for row in results:
+        assert set(row.keys()) == {"feature", "geom", "wkt", "boxWKT"}
+
+    for row in results:
+        for v in row.values():
+            assert isinstance(v, str)
+            assert v is not None
+
+    normalized_results = [
+        {
+            "feature": str(r["feature"]).strip("<>"),
+            "geom": str(r["geom"]).strip("<>"),
+            "wkt": str(r["wkt"]),
+            "boxWKT": str(r["boxWKT"]),
+        }
+        for r in results
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_results} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+    assert len(results) == len({tuple(sorted(r.items())) for r in normalized_results})
+
+
+def test_execute_geosparql():
+    """End-to-end test for execute() using several GeoSPARQL spatial functions."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    point_outside = "POINT(23.7600 38.0100)"
+    polygon_overlap = (
+        "POLYGON((23.7350 37.9850, 23.7500 37.9850, "
+        "23.7500 37.9950, 23.7350 37.9950, 23.7350 37.9850))"
+    )
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureOutside a ex:Feature ;
+            geo:hasGeometry ex:geomOutside .
+        ex:geomOutside a geo:Geometry ;
+            geo:asWKT "{point_outside}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+
+        ex:featureOverlap a ex:Feature ;
+            geo:hasGeometry ex:geomOverlap .
+        ex:geomOverlap a geo:Geometry ;
+            geo:asWKT "{polygon_overlap}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(insert_q)
+    assert out is None
+
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    within_q = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature NOT IN (ex:featureBox, ex:featureOverlap, ex:featureOutside))
+    }}
+    """
+    within_res = store.execute(within_q)
+    assert isinstance(within_res, list)
+    within_features = {str(r["feature"]).strip("<>") for r in within_res}
+    assert within_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+    }
+
+    contains_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomA geo:asWKT ?pointWKT .
+        FILTER(geof:sfContains(?boxWKT, ?pointWKT))
+      }}
+    }}
+    """
+    contains_res = store.execute(contains_q)
+    assert isinstance(contains_res, bool)
+    assert contains_res is True
+
+    intersects_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomOverlap geo:asWKT ?overlapWKT .
+        FILTER(geof:sfIntersects(?boxWKT, ?overlapWKT))
+      }}
+    }}
+    """
+    intersects_res = store.execute(intersects_q)
+    assert isinstance(intersects_res, bool)
+    assert intersects_res is True
+
+    disjoint_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomOutside geo:asWKT ?outsideWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfDisjoint(?outsideWKT, ?boxWKT))
+      }}
+    }}
+    """
+    disjoint_res = store.execute(disjoint_q)
+    assert isinstance(disjoint_res, bool)
+    assert disjoint_res is True
+
+    equals_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfEquals(?boxWKT, ?boxWKT))
+      }}
+    }}
+    """
+    equals_res = store.execute(equals_q)
+    assert isinstance(equals_res, bool)
+    assert equals_res is True
+
+    distance_q = f"""
+    {PREFIXES}
+    SELECT ?dist
+    WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomA geo:asWKT ?a .
+        ex:geomB geo:asWKT ?b .
+        BIND(geof:distance(?a, ?b, uom:metre) AS ?dist)
+      }}
+    }}
+    """
+    distance_res = store.execute(distance_q)
+    assert isinstance(distance_res, list)
+    assert len(distance_res) == 1
+    assert "dist" in distance_res[0]
+    assert float(str(distance_res[0]["dist"])) > 0
+
+    construct_q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+    cons = store.execute(construct_q)
+    assert isinstance(cons, str)
+    assert "featureA" in cons
+    assert "geomA" in cons
+    assert "featureBox" in cons
+    assert "geomBox" in cons
+
+    delete_q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{EX}featureA> <{PREDICATE}> <{EX}geomA> }} }}"
+    del_out = store.execute(delete_q)
+    assert del_out is None
+
+    verify_delete_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    assert store.execute(verify_delete_q) is False
+
+    clear_q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(clear_q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False

--- a/triplestore/tests_GeoSPARQL/test_rdf4j.py
+++ b/triplestore/tests_GeoSPARQL/test_rdf4j.py
@@ -8,8 +8,11 @@ All operations are scoped within the named graph 'http://example.org/test',
 and use a local RDF4J instance with REST API access.
 """
 
+import csv
+import json
 import tempfile
 import time
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -47,6 +50,9 @@ WHERE {{
   }}
 }}
 """
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 def is_rdf4j_available() -> bool:
@@ -916,3 +922,553 @@ def test_execute_geosparql():
     clr_out = store.execute(clear_q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def _load_basic_geosparql_dataset(store: Triplestore) -> None:
+    """Load a small GeoSPARQL dataset used by export-oriented tests."""
+    store.clear()
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+
+def test_query_export_json_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_results_json"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_results_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in data
+    ]
+
+    expected_rows = [
+        {"feature": f"{EX}featureA", "geom": f"{EX}geomA", "wkt": POINT_A},
+        {"feature": f"{EX}featureB", "geom": f"{EX}geomB", "wkt": POINT_B},
+        {"feature": f"{EX}featureBox", "geom": f"{EX}geomBox", "wkt": POLYGON},
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_rows} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+
+def test_query_export_csv_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_results_csv"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_results_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in rows
+    ]
+
+    expected_rows = [
+        {"feature": f"{EX}featureA", "geom": f"{EX}geomA", "wkt": POINT_A},
+        {"feature": f"{EX}featureB", "geom": f"{EX}geomB", "wkt": POINT_B},
+        {"feature": f"{EX}featureBox", "geom": f"{EX}geomBox", "wkt": POLYGON},
+    ]
+
+    assert {tuple(sorted(r.items())) for r in normalized_rows} == {
+        tuple(sorted(r.items())) for r in expected_rows
+    }
+
+
+def test_query_export_csv_with_custom_separator_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV using a custom separator."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_query_export_empty_results_json_geosparql():
+    """Test exporting an empty GeoSPARQL SELECT result set to JSON."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_empty_json"
+    results = store.query(
+        f"""
+        {PREFIXES}
+        SELECT ?feature ?geom ?wkt
+        WHERE {{
+          GRAPH <{GRAPH}> {{
+            <http://example.org/unknown> geo:hasGeometry ?geom .
+            ?geom geo:asWKT ?wkt .
+            BIND(<http://example.org/unknown> AS ?feature)
+          }}
+        }}
+        """,
+        export=True, output_format="json", filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_empty_json.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_rejects_non_select_geosparql():
+    """Test that query() rejects non-SELECT GeoSPARQL/SPARQL queries."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"""
+        {PREFIXES}
+        ASK WHERE {{
+          GRAPH <{GRAPH}> {{
+            ?feature geo:hasGeometry ?geom .
+          }}
+        }}
+        """)
+
+
+def test_query_rejects_unsupported_export_format_geosparql():
+    """Test that query() rejects unsupported export formats for GeoSPARQL SELECT queries."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename=str(TEST_FILES_DIR / "bad_geo_output"))
+
+
+def test_execute_export_select_json_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_json"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+
+def test_execute_export_select_csv_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_csv"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_execute_export_ask_json_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to JSON correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_json"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to TXT correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_txt"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_construct"
+    sparql = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "featureA" in content
+    assert "geomA" in content
+
+
+def test_execute_export_describe_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL DESCRIBE results to Turtle correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert SUBJECT in content
+
+
+def test_execute_rejects_unsupported_export_format_for_ask_geosparql():
+    """Test that execute() rejects unsupported export formats for GeoSPARQL ASK queries."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_geosparql_ask"))
+
+
+def test_execute_rejects_export_for_update_operations_geosparql():
+    """Test that execute() rejects export for GeoSPARQL update operations."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_geosparql_update"))
+
+
+def test_query_export_geojson_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_results_geojson"
+    results = store.query(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_results_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+    returned_features = {
+        feature["properties"]["feature"].strip("<>")
+        for feature in data["features"]
+    }
+    assert returned_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+        f"{EX}featureBox",
+    }
+
+    for feature in data["features"]:
+        assert feature["type"] == "Feature"
+        assert "geometry" in feature
+        assert "properties" in feature
+        assert feature["geometry"]["type"] in {"Point", "Polygon"}
+
+
+def test_execute_export_geojson_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_geojson"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+
+def test_query_export_geojson_rejects_non_geojson_values():
+    """Test that GeoJSON export fails when the SELECT results contain neither GeoJSON nor WKT."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Cannot export SELECT results as geospatial data"):
+        store.query(sparql, export=True, output_format="geojson", filename=str(TEST_FILES_DIR / "bad_geosparql_geojson"))
+
+
+def test_query_export_empty_results_geojson():
+    """Test exporting an empty GeoSPARQL SELECT result set to GeoJSON."""
+    store = Triplestore("rdf4j", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?wkt
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        BIND(<http://example.org/unknown> AS ?feature)
+      }}
+    }}
+    """
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_empty_geojson"
+    results = store.query(sparql, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_empty_geojson.geojson"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"type": "FeatureCollection", "features": []}
+
+
+def test_query_export_kml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KML correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_results_kml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_results_kml.kml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "<kml" in content
+    assert "<Placemark>" in content
+    assert "<Point>" in content or "<Polygon>" in content
+
+
+def test_query_export_kmz_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_results_kmz"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_results_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_execute_export_kmz_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_kmz"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_query_export_gml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GML correctly."""
+    store = Triplestore("rdf4j", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "rdf4j_geosparql_results_gml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="gml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "rdf4j_geosparql_results_gml.gml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "FeatureCollection" in content
+    assert "featureMember" in content
+    assert "Point" in content or "Polygon" in content

--- a/triplestore/tests_GeoSPARQL/test_virtuoso.py
+++ b/triplestore/tests_GeoSPARQL/test_virtuoso.py
@@ -1,0 +1,913 @@
+# Copyright (C) 2025 Maira Papadopoulou
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GeoSPARQL tests for the Virtuoso backend of the triplestore abstraction layer.
+
+All operations are scoped within a named graph, and use a local Virtuoso instance with SPARQL HTTP access.
+"""
+
+import os
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from requests.auth import HTTPDigestAuth
+from triplestore import Triplestore
+
+BASE_URL = "http://localhost:8890"
+
+SUBJECT = "http://example.org/featureA"
+PREDICATE = "http://www.opengis.net/ont/geosparql#hasGeometry"
+OBJECT = "http://example.org/geomA"
+
+GRAPH = f"http://example.org/testns-{int(time.time())}"
+EX = "http://example.org/"
+GEO = "http://www.opengis.net/ont/geosparql#"
+
+POINT_A = "POINT(23.7275 37.9838)"
+POINT_B = "POINT(23.7300 37.9845)"
+POLYGON = "POLYGON((23.7200 37.9800, 23.7400 37.9800, 23.7400 37.9900, 23.7200 37.9900, 23.7200 37.9800))"
+
+PREFIXES = """
+PREFIX ex:   <http://example.org/>
+PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+"""
+
+SPARQL_QUERY = f"""
+{PREFIXES}
+SELECT ?feature ?geom ?wkt
+WHERE {{
+  GRAPH <{GRAPH}> {{
+    ?feature geo:hasGeometry ?geom .
+    ?geom geo:asWKT ?wkt .
+  }}
+}}
+"""
+
+
+def is_virtuoso_available() -> bool:
+    try:
+        response = requests.get(f"{BASE_URL}/sparql", timeout=5, auth=HTTPDigestAuth(os.getenv("VIRTUOSO_USERNAME"), os.getenv("VIRTUOSO_PASSWORD")))
+    except requests.RequestException:
+        return False
+    else:
+        return response.status_code in {200, 401, 403}
+
+
+pytestmark = pytest.mark.skipif(
+    not is_virtuoso_available(),
+    reason="Virtuoso instance is not reachable at the configured base_url",
+)
+
+
+config = {
+    "base_url": BASE_URL,
+    "graph": GRAPH,
+}
+
+
+def test_add_and_query_triple():
+    """Test adding a geometry triple-pattern and retrieving it via GeoSPARQL/SPARQL."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    query = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query)
+
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 1
+    row = results[0]
+    assert row["feature"] == SUBJECT
+    assert row["geom"] == OBJECT
+    assert "POINT" in row["wkt"]
+
+
+def test_multiple_triples_query():
+    """Test querying multiple geometries that are within the same polygon."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    query1 = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(query1)
+
+    query2 = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """
+    results = store.query(query2)
+    features = [str(row["feature"]).strip("<>") for row in results]
+
+    assert f"{EX}featureA" in features
+    assert f"{EX}featureB" in features
+    assert len(features) == 2
+
+
+def test_delete_triple():
+    """Test that deleting a geometry relation removes it from the store."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    before = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(before) == 1
+
+    store.delete(SUBJECT, PREDICATE, OBJECT)
+
+    after = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(after) == 0
+
+
+def test_query_roundtrip_add():
+    """Test add-delete-add cycle for a geometry relation."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    initial_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    row = next(iter(initial_results))
+    s = str(row["feature"]).strip("<>")
+    o = str(row["geom"]).strip("<>")
+
+    store.delete(s, PREDICATE, o)
+
+    after_delete = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert not any(
+        str(r["feature"]).strip("<>") == s
+        and str(r["geom"]).strip("<>") == o
+        for r in after_delete
+    )
+
+    store.add(s, PREDICATE, o)
+
+    final_results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    count = sum(
+        1
+        for r in final_results
+        if str(r["feature"]).strip("<>") == s
+        and str(r["geom"]).strip("<>") == o
+    )
+    assert count == 1
+
+
+def test_query_returns_empty_when_no_match():
+    """Test that a GeoSPARQL/SPARQL query returns no results when no match exists."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+    assert len(results) == 0
+
+
+def test_load_from_turtle_file():
+    """Test loading GeoSPARQL triples from a .ttl file into the store."""
+    turtle_data = f"""
+    @prefix ex: <http://example.org/> .
+    @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+    ex:featureA a ex:Feature ;
+        geo:hasGeometry ex:geomA .
+
+    ex:geomA a geo:Geometry ;
+        geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+    """
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".ttl", encoding="utf-8") as f:
+        f.write(turtle_data)
+        tmp_path = f.name
+
+    try:
+        store = Triplestore("virtuoso", config=config)
+        store.clear()
+        store.load(tmp_path)
+
+        results = store.query(SPARQL_QUERY)
+
+        assert len(results) == 1
+        row = results[0]
+        assert row["feature"] == f"{EX}featureA"
+        assert row["geom"] == f"{EX}geomA"
+        assert "POINT" in row["wkt"]
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def test_clear():
+    """Test that clear() removes all geometries from the store."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_clear_twice_is_safe():
+    """Test that calling clear() multiple times doesn't raise or fail."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+    store.clear()
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+    store.clear()
+    results = store.query(SPARQL_QUERY)
+
+    assert len(results) == 0
+
+
+def test_execute():
+    """End-to-end test for execute() using GeoSPARQL-aware data and queries."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(q)
+    assert out is None
+
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    q = f"""
+    {PREFIXES}
+    SELECT ?feature WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry <{OBJECT}> .
+      }}
+    }}
+    """
+    sel = store.execute(q)
+    assert isinstance(sel, list)
+    assert len(sel) == 1
+    subjects = [str(r["feature"]).strip("<>") for r in sel]
+    assert SUBJECT in subjects
+
+    q = f"""
+        DESCRIBE <{SUBJECT}>
+        FROM <{graph}>
+    """
+    desc = store.execute(q)
+    assert isinstance(desc, str)
+    assert "featureA" in desc
+    assert "geomA" in desc
+
+    q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature ?p ?o }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature ?p ?o .
+      }}
+    }}
+    """
+    cons = store.execute(q)
+    assert isinstance(cons, str)
+    assert "featureA" in cons
+    assert "geomA" in cons
+
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+    geo_q = f"""
+    {PREFIXES}
+    SELECT ?dist
+    WHERE {{
+      GRAPH <{graph}> {{
+        <{OBJECT}> geo:asWKT ?a .
+        ex:geomB geo:asWKT ?b .
+        BIND(geof:distance(?a, ?b, uom:metre) AS ?dist)
+      }}
+    }}
+    """
+    geo_res = store.execute(geo_q)
+    assert isinstance(geo_res, list)
+    assert len(geo_res) == 1
+    assert float(geo_res[0]["dist"]) > 0.0
+
+    q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{SUBJECT}> <{PREDICATE}> <{OBJECT}> }} }}"
+    del_out = store.execute(q)
+    assert del_out is None
+    assert store.execute(ask_q) is False
+
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            geo:hasGeometry <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+    q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def test_add_duplicate_triple():
+    """Test that adding the same triple twice does not create duplicate query results."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.add(SUBJECT, PREDICATE, OBJECT)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    count = sum(
+        1
+        for r in results
+        if str(r["feature"]).strip("<>") == SUBJECT
+        and str(r["geom"]).strip("<>") == OBJECT
+    )
+    assert count == 1
+
+
+def test_delete_nonexistent_triple():
+    """Test that deleting a triple that does not exist does not raise or affect existing data."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    store.delete(
+        "http://example.org/nonexistentFeature",
+        PREDICATE,
+        "http://example.org/nonexistentGeom",
+    )
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <{SUBJECT}> geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results) == 1
+    assert str(results[0]["geom"]).strip("<>") == OBJECT
+
+
+def test_named_graph():
+    """Test that queries scoped to the configured graph do not see triples from another named graph."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    other_graph = "http://example.org/other"
+
+    q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{other_graph}> {{
+        <{SUBJECT}> a ex:Feature ;
+            <{PREDICATE}> <{OBJECT}> .
+        <{OBJECT}> a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(q)
+
+    results_in_test_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_test_graph) == 0
+
+    results_in_other_graph = store.query(f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{other_graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """)
+
+    assert len(results_in_other_graph) == 1
+    row = results_in_other_graph[0]
+    assert str(row["feature"]).strip("<>") == SUBJECT
+    assert str(row["geom"]).strip("<>") == OBJECT
+
+
+def test_select_star():
+    """Test SELECT * for GeoSPARQL data: verifies bindings for feature, geometry, and WKT."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    store.execute(insert_q)
+
+    results = store.query(f"""
+    {PREFIXES}
+    SELECT * WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?wkt, ?boxWKT))
+      }}
+      FILTER(?feature != ex:featureBox)
+    }}
+    """)
+
+    assert len(results) == 2
+
+    for row in results:
+        assert set(row.keys()) == {"feature", "geom", "wkt", "boxWKT"}
+        assert all(isinstance(value, str) and value for value in row.values())
+
+    normalized_pairs = {
+        (str(row["feature"]).strip("<>"), str(row["geom"]).strip("<>"))
+        for row in results
+    }
+
+    assert normalized_pairs == {
+        (f"{EX}featureA", f"{EX}geomA"),
+        (f"{EX}featureB", f"{EX}geomB"),
+    }
+
+    wkts = {str(row["wkt"]) for row in results}
+    box_wkts = {str(row["boxWKT"]) for row in results}
+
+    assert len(box_wkts) == 1
+    assert all(wkt.startswith("POINT(") for wkt in wkts)
+    assert next(iter(box_wkts)).startswith("POLYGON(")
+
+    assert len(results) == len(normalized_pairs)
+
+
+def test_execute_geosparql():
+    """End-to-end test for execute() using several GeoSPARQL spatial functions."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    graph = config["graph"]
+
+    point_outside = "POINT(23.7600 38.0100)"
+    polygon_overlap = (
+        "POLYGON((23.7350 37.9850, 23.7500 37.9850, "
+        "23.7500 37.9950, 23.7350 37.9950, 23.7350 37.9850))"
+    )
+
+    insert_q = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{graph}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureOutside a ex:Feature ;
+            geo:hasGeometry ex:geomOutside .
+        ex:geomOutside a geo:Geometry ;
+            geo:asWKT "{point_outside}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+
+        ex:featureOverlap a ex:Feature ;
+            geo:hasGeometry ex:geomOverlap .
+        ex:geomOverlap a geo:Geometry ;
+            geo:asWKT "{polygon_overlap}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+    out = store.execute(insert_q)
+    assert out is None
+
+    ask_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    ask_res = store.execute(ask_q)
+    assert isinstance(ask_res, bool)
+    assert ask_res is True
+
+    within_q = f"""
+    {PREFIXES}
+    SELECT ?feature
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?pointWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfWithin(?pointWKT, ?boxWKT))
+      }}
+      FILTER(?feature NOT IN (ex:featureBox, ex:featureOverlap, ex:featureOutside))
+    }}
+    """
+    within_res = store.execute(within_q)
+    assert isinstance(within_res, list)
+    within_features = {str(r["feature"]).strip("<>") for r in within_res}
+    assert within_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+    }
+
+    contains_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomA geo:asWKT ?pointWKT .
+        FILTER(geof:sfContains(?boxWKT, ?pointWKT))
+      }}
+    }}
+    """
+    contains_res = store.execute(contains_q)
+    assert isinstance(contains_res, bool)
+    assert contains_res is True
+
+    intersects_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        ex:geomOverlap geo:asWKT ?overlapWKT .
+        FILTER(geof:sfIntersects(?boxWKT, ?overlapWKT))
+      }}
+    }}
+    """
+    intersects_res = store.execute(intersects_q)
+    assert isinstance(intersects_res, bool)
+    assert intersects_res is True
+
+    disjoint_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomOutside geo:asWKT ?outsideWKT .
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfDisjoint(?outsideWKT, ?boxWKT))
+      }}
+    }}
+    """
+    disjoint_res = store.execute(disjoint_q)
+    assert isinstance(disjoint_res, bool)
+    assert disjoint_res is True
+
+    equals_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomBox geo:asWKT ?boxWKT .
+        FILTER(geof:sfEquals(?boxWKT, ?boxWKT))
+      }}
+    }}
+    """
+    equals_res = store.execute(equals_q)
+    assert isinstance(equals_res, bool)
+    assert equals_res is True
+
+    distance_q = f"""
+    {PREFIXES}
+    SELECT ?dist
+    WHERE {{
+      GRAPH <{graph}> {{
+        ex:geomA geo:asWKT ?a .
+        ex:geomB geo:asWKT ?b .
+        BIND(geof:distance(?a, ?b, uom:metre) AS ?dist)
+      }}
+    }}
+    """
+    distance_res = store.execute(distance_q)
+    assert isinstance(distance_res, list)
+    assert len(distance_res) == 1
+    assert "dist" in distance_res[0]
+    assert float(str(distance_res[0]["dist"])) > 0
+
+    construct_q = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{graph}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+    cons = store.execute(construct_q)
+    assert isinstance(cons, str)
+    assert "featureA" in cons
+    assert "geomA" in cons
+    assert "featureBox" in cons
+    assert "geomBox" in cons
+
+    delete_q = f"DELETE DATA {{ GRAPH <{graph}> {{ <{EX}featureA> <{PREDICATE}> <{EX}geomA> }} }}"
+    del_out = store.execute(delete_q)
+    assert del_out is None
+
+    verify_delete_q = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{graph}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+    assert store.execute(verify_delete_q) is False
+
+    clear_q = f"CLEAR GRAPH <{graph}>"
+    clr_out = store.execute(clear_q)
+    assert clr_out is None
+    assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False

--- a/triplestore/tests_GeoSPARQL/test_virtuoso.py
+++ b/triplestore/tests_GeoSPARQL/test_virtuoso.py
@@ -7,14 +7,18 @@ GeoSPARQL tests for the Virtuoso backend of the triplestore abstraction layer.
 All operations are scoped within a named graph, and use a local Virtuoso instance with SPARQL HTTP access.
 """
 
+import csv
+import json
 import os
 import tempfile
 import time
+import zipfile
 from pathlib import Path
 
 import pytest
 import requests
 from requests.auth import HTTPDigestAuth
+from shapely import wkt as shapely_wkt
 from triplestore import Triplestore
 
 BASE_URL = "http://localhost:8890"
@@ -48,6 +52,9 @@ WHERE {{
   }}
 }}
 """
+
+TEST_FILES_DIR = Path(__file__).parent / "tests_files"
+TEST_FILES_DIR.mkdir(exist_ok=True)
 
 
 def is_virtuoso_available() -> bool:
@@ -911,3 +918,567 @@ def test_execute_geosparql():
     clr_out = store.execute(clear_q)
     assert clr_out is None
     assert store.execute(f"ASK WHERE {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}") is False
+
+
+def _load_basic_geosparql_dataset(store: Triplestore) -> None:
+    """Load a small GeoSPARQL dataset used by export-oriented tests."""
+    store.clear()
+    store.execute(f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+
+        ex:featureB a ex:Feature ;
+            geo:hasGeometry ex:geomB .
+
+        ex:geomB a geo:Geometry ;
+            geo:asWKT "{POINT_B}"^^geo:wktLiteral .
+
+        ex:featureBox a ex:Feature ;
+            geo:hasGeometry ex:geomBox .
+
+        ex:geomBox a geo:Geometry ;
+            geo:asWKT "{POLYGON}"^^geo:wktLiteral .
+      }}
+    }}
+    """)
+
+
+def _same_wkt_geometry(left: str, right: str, tolerance: float = 1e-5) -> bool:
+    left_geom = shapely_wkt.loads(left)
+    right_geom = shapely_wkt.loads(right)
+    return left_geom.equals_exact(right_geom, tolerance=tolerance)
+
+
+def test_query_export_json_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_results_json"
+    results = store.query(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_results_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in data
+    ]
+
+    expected_rows = {
+        f"{EX}featureA": {"geom": f"{EX}geomA", "wkt": POINT_A},
+        f"{EX}featureB": {"geom": f"{EX}geomB", "wkt": POINT_B},
+        f"{EX}featureBox": {"geom": f"{EX}geomBox", "wkt": POLYGON},
+    }
+
+    assert len(normalized_rows) == 3
+
+    for row in normalized_rows:
+        expected = expected_rows[row["feature"]]
+        assert row["geom"] == expected["geom"]
+        assert _same_wkt_geometry(row["wkt"], expected["wkt"])
+
+
+def test_query_export_csv_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_results_csv"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_results_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+
+    normalized_rows = [
+        {
+            "feature": row["feature"].strip("<>"),
+            "geom": row["geom"].strip("<>"),
+            "wkt": row["wkt"],
+        }
+        for row in rows
+    ]
+
+    expected_rows = {
+        f"{EX}featureA": {"geom": f"{EX}geomA", "wkt": POINT_A},
+        f"{EX}featureB": {"geom": f"{EX}geomB", "wkt": POINT_B},
+        f"{EX}featureBox": {"geom": f"{EX}geomBox", "wkt": POLYGON},
+    }
+
+    assert len(normalized_rows) == 3
+
+    for row in normalized_rows:
+        expected = expected_rows[row["feature"]]
+        assert row["geom"] == expected["geom"]
+        assert _same_wkt_geometry(row["wkt"], expected["wkt"])
+
+
+def test_query_export_csv_with_custom_separator_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to CSV using a custom separator."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_custom_separator"
+    results = store.query(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file), separator=";")
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_custom_separator.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert ";" in content
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_query_export_empty_results_json_geosparql():
+    """Test exporting an empty GeoSPARQL SELECT result set to JSON."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_empty_json"
+    results = store.query(
+        f"""
+        {PREFIXES}
+        SELECT ?feature ?geom ?wkt
+        WHERE {{
+          GRAPH <{GRAPH}> {{
+            <http://example.org/unknown> geo:hasGeometry ?geom .
+            ?geom geo:asWKT ?wkt .
+            BIND(<http://example.org/unknown> AS ?feature)
+          }}
+        }}
+        """,
+        export=True, output_format="json", filename=str(output_file),
+    )
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_empty_json.json"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == []
+
+
+def test_query_rejects_non_select_geosparql():
+    """Test that query() rejects non-SELECT GeoSPARQL/SPARQL queries."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match=r"Only SELECT queries are supported"):
+        store.query(f"""
+        {PREFIXES}
+        ASK WHERE {{
+          GRAPH <{GRAPH}> {{
+            ?feature geo:hasGeometry ?geom .
+          }}
+        }}
+        """)
+
+
+def test_query_rejects_unsupported_export_format_geosparql():
+    """Test that query() rejects unsupported export formats for GeoSPARQL SELECT queries."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.query(SPARQL_QUERY, export=True, output_format="ttl", filename=str(TEST_FILES_DIR / "bad_geo_output"))
+
+
+def test_execute_export_select_json_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to JSON correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_json"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_json.json"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == results
+
+
+def test_execute_export_select_csv_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to CSV correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_csv"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="csv", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_csv.csv"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with exported_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == {"feature", "geom", "wkt"}
+
+
+def test_execute_export_ask_json_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to JSON correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_json"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="json", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_json.json"
+
+    assert exported_path.exists()
+    assert result is True
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"boolean": True}
+
+
+def test_execute_export_ask_txt_geosparql():
+    """Test that execute() exports GeoSPARQL ASK results to TXT correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_ask_txt"
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA geo:hasGeometry ex:geomA .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="txt", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_ask_txt.txt"
+
+    assert exported_path.exists()
+    assert result is True
+    assert exported_path.read_text(encoding="utf-8").strip() == "true"
+
+
+def test_execute_export_construct_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL CONSTRUCT results to Turtle correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_construct"
+    sparql = f"""
+    {PREFIXES}
+    CONSTRUCT {{ ?feature geo:hasGeometry ?geom }}
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_construct.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "featureA" in content
+    assert "geomA" in content
+
+
+def test_execute_export_describe_ttl_geosparql():
+    """Test that execute() exports GeoSPARQL DESCRIBE results to Turtle correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_describe"
+    sparql = f"DESCRIBE <{SUBJECT}>"
+
+    result = store.execute(sparql, export=True, output_format="ttl", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_describe.ttl"
+
+    assert exported_path.exists()
+    assert isinstance(result, str)
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert content.splitlines() == result.splitlines()
+    assert "featureA" in content
+    assert "geomA" in content
+    assert "hasGeometry" in content
+
+
+def test_execute_rejects_unsupported_export_format_for_ask_geosparql():
+    """Test that execute() rejects unsupported export formats for GeoSPARQL ASK queries."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    ASK WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="csv", filename=str(TEST_FILES_DIR / "bad_geosparql_ask"))
+
+
+def test_execute_rejects_export_for_update_operations_geosparql():
+    """Test that execute() rejects export for GeoSPARQL update operations."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    INSERT DATA {{
+      GRAPH <{GRAPH}> {{
+        ex:featureA a ex:Feature ;
+            geo:hasGeometry ex:geomA .
+        ex:geomA a geo:Geometry ;
+            geo:asWKT "{POINT_A}"^^geo:wktLiteral .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Unsupported export format"):
+        store.execute(sparql, export=True, output_format="json", filename=str(TEST_FILES_DIR / "bad_geosparql_update"))
+
+
+def test_query_export_geojson_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_results_geojson"
+    results = store.query(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_results_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+    returned_features = {
+        feature["properties"]["feature"].strip("<>")
+        for feature in data["features"]
+    }
+    assert returned_features == {
+        f"{EX}featureA",
+        f"{EX}featureB",
+        f"{EX}featureBox",
+    }
+
+    for feature in data["features"]:
+        assert feature["type"] == "Feature"
+        assert "geometry" in feature
+        assert "properties" in feature
+        assert feature["geometry"]["type"] in {"Point", "Polygon"}
+
+
+def test_execute_export_geojson_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to GeoJSON correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_geojson"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_geojson.geojson"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+
+def test_query_export_geojson_rejects_non_geojson_values():
+    """Test that GeoJSON export fails when the SELECT results contain neither GeoJSON nor WKT."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?geom
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        ?feature geo:hasGeometry ?geom .
+      }}
+    }}
+    """
+
+    with pytest.raises(ValueError, match="Cannot export SELECT results as geospatial data"):
+        store.query(sparql, export=True, output_format="geojson", filename=str(TEST_FILES_DIR / "bad_geosparql_geojson"))
+
+
+def test_query_export_empty_results_geojson():
+    """Test exporting an empty GeoSPARQL SELECT result set to GeoJSON."""
+    store = Triplestore("virtuoso", config=config)
+    store.clear()
+
+    sparql = f"""
+    {PREFIXES}
+    SELECT ?feature ?wkt
+    WHERE {{
+      GRAPH <{GRAPH}> {{
+        <http://example.org/unknown> geo:hasGeometry ?geom .
+        ?geom geo:asWKT ?wkt .
+        BIND(<http://example.org/unknown> AS ?feature)
+      }}
+    }}
+    """
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_empty_geojson"
+    results = store.query(sparql, export=True, output_format="geojson", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_empty_geojson.geojson"
+
+    assert results == []
+    assert exported_path.exists()
+
+    data = json.loads(exported_path.read_text(encoding="utf-8"))
+    assert data == {"type": "FeatureCollection", "features": []}
+
+
+def test_query_export_kml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KML correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_results_kml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_results_kml.kml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "<kml" in content
+    assert "<Placemark>" in content
+    assert "<Point>" in content or "<Polygon>" in content
+
+
+def test_query_export_kmz_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_results_kmz"
+    results = store.query(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_results_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_execute_export_kmz_geosparql():
+    """Test that execute() exports GeoSPARQL SELECT results to KMZ correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "execute_geosparql_select_kmz"
+    results = store.execute(SPARQL_QUERY, export=True, output_format="kmz", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "execute_geosparql_select_kmz.kmz"
+
+    assert exported_path.exists()
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+    with zipfile.ZipFile(exported_path, "r") as kmz_file:
+        names = kmz_file.namelist()
+        assert "doc.kml" in names
+
+        kml_content = kmz_file.read("doc.kml").decode("utf-8")
+        assert "<kml" in kml_content
+        assert "<Placemark>" in kml_content
+
+
+def test_query_export_gml_geosparql():
+    """Test that query() exports GeoSPARQL SELECT results to GML correctly."""
+    store = Triplestore("virtuoso", config=config)
+    _load_basic_geosparql_dataset(store)
+
+    output_file = TEST_FILES_DIR / "virtuoso_geosparql_results_gml"
+    results = store.query(SPARQL_QUERY, export=True, output_format="gml", filename=str(output_file))
+
+    exported_path = TEST_FILES_DIR / "virtuoso_geosparql_results_gml.gml"
+
+    assert exported_path.exists()
+    assert len(results) == 3
+
+    content = exported_path.read_text(encoding="utf-8")
+    assert "FeatureCollection" in content
+    assert "featureMember" in content
+    assert "Point" in content or "Polygon" in content


### PR DESCRIPTION
- New backends added: Support for RDF4J, Virtuoso, and QLever has been integrated.
- Extended triple manipulation support: The add() and delete() operations now support blank nodes and literals (in addition to URIs).
- Enhanced export functionality: Both query() and execute() now support exporting results in multiple formats: .json, .csv, and .ttl.
- Improved data loading:The load() method now supports N-Triples (.nt) files in addition to Turtle (.ttl).
- GeoSPARQL support and geospatial exports: Extended GeoSPARQL support across GraphDB, Apache Jena, QLever, AllegroGraph, RDF4J, and Virtuoso and query results can now be exported in geospatial formats too, .geojson, .kmz, .kml, and .gml.