### PR TITLE
Make geospatial support optional

### DIFF
--- a/triplestore/pyproject.toml
+++ b/triplestore/pyproject.toml
@@ -10,9 +10,7 @@ authors = [
 
 requires-python = ">=3.10"
 
-dependencies = [
-    "shapely>=2.1.2",
-]
+dependencies = []
 
 [build-system]
 requires = ["hatchling"]
@@ -40,6 +38,8 @@ qlever = ["requests>=2.32.4"]
 rdf4j = ["requests>=2.32.4"]
 
 virtuoso = ["requests>=2.32.4"]
+
+geo = ["shapely>=2.1.2"]
 
 all = [
     "agraph-python>=104.3.0",

--- a/triplestore/src/triplestore/backends/jena_utils.py
+++ b/triplestore/src/triplestore/backends/jena_utils.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Maira Papadopoulou
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib.util
 import os
 import re
 import shutil
@@ -189,6 +190,10 @@ def find_jena_geosparql_jar() -> str:
     raise FileNotFoundError(msg)
 
 
+def is_geo_extra_available() -> bool:
+    return importlib.util.find_spec("shapely") is not None
+
+
 def start_fuseki_server(dataset_name: str, host: str = "localhost", port: int = 3030, *, show_server_logs: bool = False) -> Path:
     """
     Start a local SPARQL/GeoSPARQL-enabled Fuseki server backed by a TDB2 dataset directory.
@@ -220,14 +225,17 @@ def start_fuseki_server(dataset_name: str, host: str = "localhost", port: int = 
     dataset_dir = tdb2_loc / service
     dataset_dir.mkdir(parents=True, exist_ok=True)
 
-    geosparql_jar = find_jena_geosparql_jar()
-
     env = os.environ.copy()
     env.setdefault("JAVA_TOOL_OPTIONS", "-Xms4g -Xmx8g")
     env.setdefault("FUSEKI_BASE", str(Path.home() / "fuseki" / "base"))
     Path(env["FUSEKI_BASE"]).mkdir(parents=True, exist_ok=True)
 
-    cmd = ["java", "-jar", geosparql_jar, "-p", str(port), "-d", service, "-u", "-t2", "-t", str(dataset_dir), "-i"]
+    if is_geo_extra_available():
+        geosparql_jar = find_jena_geosparql_jar()
+        cmd = ["java", "-jar", geosparql_jar, "-p", str(port), "-d", service, "-u", "-t2", "-t", str(dataset_dir), "-i"]
+    else:
+        fuseki_server = find_fuseki_server()
+        cmd = [fuseki_server, "--port", str(port), "--update", "--tdb2", "--loc", str(dataset_dir), f"/{service}"]
 
     if show_server_logs:
         subprocess.Popen(cmd, env=env)

--- a/triplestore/src/triplestore/utils.py
+++ b/triplestore/src/triplestore/utils.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any
 
 from triplestore.exceptions import TriplestoreMissingConfigValue
-from triplestore.utils_geo import export_geospatial_select_results
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +29,8 @@ SPARQL_DEFAULT_EXPORT_FORMATS = {
     "CONSTRUCT": "ttl",
     "DESCRIBE": "ttl",
 }
+
+GEOSPATIAL_EXPORT_FORMATS = {"geojson", "kml", "kmz", "gml"}
 
 SPARQL_ALLOWED_EXPORT_FORMATS = {
     "SELECT": {"json", "csv", "geojson", "kml", "kmz", "gml"},
@@ -231,6 +232,19 @@ def resolve_export_format(query_type: str, *, export: bool, output_format: str |
     return chosen_format
 
 
+def _export_geospatial_select_results(*args, backend_name: str, **kwargs):
+    try:
+        from triplestore.utils_geo import export_geospatial_select_results
+    except ImportError as exc:
+        msg = (
+            f"[{backend_name}] Geospatial export requires the optional geo dependencies. "
+            "Install it with: pip install triplestore[geo]"
+        )
+        raise RuntimeError(msg) from exc
+
+    return export_geospatial_select_results(*args, backend_name=backend_name, **kwargs)
+
+
 def export_select_results(results: list[dict[str, str]], output_format: str, filename: str | None = None, separator: str = ",", backend_name: str = "backend") -> Path:
     """
     Export SELECT query results to a local file.
@@ -281,9 +295,8 @@ def export_select_results(results: list[dict[str, str]], output_format: str, fil
 
         return output_path
 
-    if normalized_format in {"geojson", "kml", "kmz", "gml"}:
-        return export_geospatial_select_results(results,
-            output_format=normalized_format, output_path=output_path, backend_name=backend_name)
+    if normalized_format in GEOSPATIAL_EXPORT_FORMATS:
+        return _export_geospatial_select_results(results, output_format=normalized_format, output_path=output_path, backend_name=backend_name)
 
     msg = f"[{backend_name}] Unsupported SELECT export format: {output_format}"
     raise ValueError(msg)


### PR DESCRIPTION
This PR makes geospatial support optional through the `geo` extra.

It removes `shapely` from the core dependencies, lazy-loads geospatial export utilities, and keeps GeoJSON/KML/KMZ/GML export available only when users install:
```bash
pip install triplestore[geo]
```